### PR TITLE
Maximum imaging run-time

### DIFF
--- a/katacomb/katacomb/conf/mfimage_MKAT.yaml
+++ b/katacomb/katacomb/conf/mfimage_MKAT.yaml
@@ -36,4 +36,3 @@ refAnt: 0                   # SC Reference antenna
 Reuse: 20.0                 # Number of sigma to reuse CCs
 doGPU: True                 # Use GPU predict
 minFList: [0.0001]          # Minimum flux density to CLEAN per Self-cal cycle after first
-maxRealtime: 21600.0        # Wall time after which MFImage will begin to shut down

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -618,6 +618,16 @@ class KatdalPipelineImplementation(PipelineImplementation):
         # Close merge file
         merge_uvf.close()
 
+    def _set_mfimage_runtime_default(self, mintime=7200., extra=0.5):
+        """
+        Get the total observed time (t_obs) currently selected in the
+        kat_adapter and set the MFImage:maxRealtime parameter to
+        max(mintime, t_obs*(1. + extra)).
+        """
+        t_obs = self.ka.shape[0] * self.ka.katdal.dump_period
+        maxRealtime = max(mintime, t_obs * (1. + extra))
+        self.mfimage_params['maxRealtime'] = maxRealtime
+
 
 @register_workmode('continuum_export')
 class KatdalExportPipeline(KatdalPipelineImplementation):
@@ -688,8 +698,10 @@ class OnlinePipeline(KatdalPipelineImplementation):
 
         super(OnlinePipeline, self).__init__(katdata)
         self.telstate = telstate
-        self.uvblavg_params = uvblavg_params
-        self.mfimage_params = mfimage_params
+        self.uvblavg_params.update(uvblavg_params)
+        # Set default maxRealtime for MFImage
+        self._set_mfimage_runtime_default()
+        self.mfimage_params.update(mfimage_params)
         self.katdal_select = katdal_select
         self.nvispio = nvispio
 


### PR DESCRIPTION
Add a continuum_pipeline method to determine a default maximum run-time for MFImage.

The default is the maximum of either 2 hours or the observation length + 50%. This can be overridden by setting the value of MFImage parameter maxRealtime at execution either at the command-line or in the configuration yaml.

Also remove the old (6 hour) default from the configuration file.