### PR TITLE
Add default parameters inferred from katdal object.

### DIFF
--- a/katacomb/katacomb/conf/mfimage_MKAT.yaml
+++ b/katacomb/katacomb/conf/mfimage_MKAT.yaml
@@ -32,7 +32,6 @@ minFluxASC: 0.01            # Min. peak A&P self cal (Jy)
 solAInt: 2.0                # A&P SC Solution interval (min)
 solAType: 'L1'              # A&P SC Soln. Type: '  ', 'L1'
 solAMode: 'A&P'             # A&P SC Soln. Mode:'A&P', 'P', 'P!A'
-refAnt: 0                   # SC Reference antenna
 Reuse: 20.0                 # Number of sigma to reuse CCs
 doGPU: True                 # Use GPU predict
 minFList: [0.0001]          # Minimum flux density to CLEAN per Self-cal cycle after first

--- a/katacomb/katacomb/conf/uvblavg_MKAT.yaml
+++ b/katacomb/katacomb/conf/uvblavg_MKAT.yaml
@@ -1,4 +1,6 @@
 # Default options for UVBlAvg
 FOV: 1.0         # Field of view (deg)
 maxInt: 0.5      # Maximum integration (min)
+                 # (Should always be less than the self calibration
+                 # interval (solPInt and solAInt) in MFImage parameters)
 maxFact: 1.01    # Maximum time smearing factor

--- a/katacomb/katacomb/conf/uvblavg_MKAT.yaml
+++ b/katacomb/katacomb/conf/uvblavg_MKAT.yaml
@@ -1,6 +1,4 @@
 # Default options for UVBlAvg
 FOV: 1.0         # Field of view (deg)
-maxInt: 1.0      # Maximum integration (min)
+maxInt: 0.5      # Maximum integration (min)
 maxFact: 1.01    # Maximum time smearing factor
-avgFreq: 0       # Frequency averaging control
-chAvg: 1         # Number of chan. to average.

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -618,16 +618,6 @@ class KatdalPipelineImplementation(PipelineImplementation):
         # Close merge file
         merge_uvf.close()
 
-    def _set_mfimage_runtime_default(self, mintime=7200., extra=0.5):
-        """
-        Get the total observed time (t_obs) currently selected in the
-        kat_adapter and set the MFImage:maxRealtime parameter to
-        max(mintime, t_obs*(1. + extra)).
-        """
-        t_obs = self.ka.shape[0] * self.ka.katdal.dump_period
-        maxRealtime = max(mintime, t_obs * (1. + extra))
-        self.mfimage_params['maxRealtime'] = maxRealtime
-
 
 @register_workmode('continuum_export')
 class KatdalExportPipeline(KatdalPipelineImplementation):
@@ -699,8 +689,6 @@ class OnlinePipeline(KatdalPipelineImplementation):
         super(OnlinePipeline, self).__init__(katdata)
         self.telstate = telstate
         self.uvblavg_params.update(uvblavg_params)
-        # Set default maxRealtime for MFImage
-        self._set_mfimage_runtime_default()
         self.mfimage_params.update(mfimage_params)
         self.katdal_select = katdal_select
         self.nvispio = nvispio

--- a/katacomb/scripts/continuum_pipeline.py
+++ b/katacomb/scripts/continuum_pipeline.py
@@ -41,7 +41,7 @@ START_TIME = '%d' % (int(time.time()*1000))
 CONFIG = '/obitconf'
 # Minimum Walltime in sec. and extra time padding for MFImage
 MINRUNTIME = 2. * 3600.
-RUNTIME_PAD = 0.5
+RUNTIME_PAD = 1.0
 
 
 def create_parser():


### PR DESCRIPTION
Infer the refant from the cal_refant and the channel averaging
so we should always average to 1K channels for continuum.

Delete relevant parameters from the configuration defaults.

Also move the maxRuntime code into the infer_defaults function.

Also Fix broken baseline averaging parameter. (This should be
the same as what we use as the self-calibration interval.)