### PR TITLE
Image export updates

### DIFF
--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -904,6 +904,10 @@ class KatdalOfflinePipeline(KatdalPipelineImplementation):
         if "merge" in self.clobber:
             self.cleanup_uv_files.append(self.uv_merge_path)
         self._run_mfimage(self.uv_merge_path, uv_sources)
+
         self._get_wavg_img(clean_files)
+	for uv, clean in zip(uv_files, clean_files):
+            self._attach_SN_tables_to_image(uv, clean)
+
         export_images(clean_files, target_indices,
                       self.odisk, self.ka)

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -241,17 +241,17 @@ class PipelineImplementation(Pipeline):
         """
         for img in image_files:
             with img_factory(aips_path=img, mode="rw") as imf:
-                tmp_img = img.copy(seq=next_seq_nr(img))
-                imf.Copy(tmp_img)
-                tmp_imf = img_factory(aips_path=tmp_img, mode="rw")
-                # nOrder=0 does weighted average of planes
-                tmp_imf.FitMF(nOrder=0)
-                # Get the first (weighted average plane)
-                img_plane = tmp_imf.GetPlane()
-                # Stick it into the first plane of img.
-                imf.PutPlane(img_plane)
-                tmp_imf.Zap()
-
+                if imf.exists:
+                    tmp_img = img.copy(seq=next_seq_nr(img))
+                    imf.Copy(tmp_img)
+                    tmp_imf = img_factory(aips_path=tmp_img, mode="rw")
+                    # nOrder=0 does weighted average of planes
+                    tmp_imf.FitMF(nOrder=0)
+                    # Get the first (weighted average plane)
+                    img_plane = tmp_imf.GetPlane()
+                    # Stick it into the first plane of img.
+                    imf.PutPlane(img_plane)
+                    tmp_imf.Zap()
 
     def _cleanup(self):
         """

--- a/katacomb/katacomb/img_facade.py
+++ b/katacomb/katacomb/img_facade.py
@@ -10,6 +10,10 @@ import ImageMF
 import Table
 import TableList
 import TableUtil
+import AIPSDir
+import FITSDir
+import OSystem
+
 
 from katacomb import (AIPSTable,
                       AIPSHistory,
@@ -261,6 +265,20 @@ class ImageFacade(object):
                         if name not in ignored_tables}
 
         self._tables["AIPS HI"] = AIPSHistory(img, err)
+
+    @property
+    def exists(self):
+        # Do I exist?
+        exists = False
+        if self.img.FileType == "FITS":
+            exists = FITSDir.PExist(self.img.FileName, self.img.Disk, self._err)
+        elif self.img.FileType == "AIPS":
+            user = OSystem.PGetAIPSuser()
+            test = AIPSDir.PTestCNO(self.img.Disk, user, self.img.Aname,
+                                    self.img.Aclass, "MA", self.img.Aseq,
+                                    self._err)
+            exists = test > 0
+        return exists
 
     @property
     def tables(self):

--- a/katacomb/katacomb/img_facade.py
+++ b/katacomb/katacomb/img_facade.py
@@ -284,6 +284,13 @@ class ImageFacade(object):
     def tables(self):
         return self._tables
 
+    @property
+    def tablelist(self):
+        tables = TableList.PGetList(self.img.TableList, self._err)
+        handle_obit_err("Error getting '%s' table list" % self.name)
+        return tables
+
+
     def attach_table(self, name, version, **kwargs):
         self._tables[name] = AIPSTable(self.img, name, version, 'r',
                                        self._err, **kwargs)
@@ -318,15 +325,17 @@ class ImageFacade(object):
         handle_obit_err(err_msg, self._err)
         self._clear_img()
 
-    def writefits(self, disk, output):
+    def writefits(self, disk, output, tables_to_copy=['AIPS CC', 'AIPS SN']):
         """ Write the image to a FITS file """
 
         err_msg = "Unable to write image to %s" % output
 
         outImage = Image.newPFImage("FITS Image DATA", output, disk, False, self._err)
         Image.PCopy(self._img, outImage, self._err)
-
+        Image.PCopyTables(self._img, outImage, ['AIPS HI'], tables_to_copy, self._err)
         handle_obit_err(err_msg, self._err)
+
+
 
     @property
     def img(self):
@@ -469,12 +478,12 @@ class ImageFacade(object):
 
         # Check we have the right type of image
         if self.isObitImageMF():
-            #try:
+            try:
                 # Need an ImageMF pointer for PFitSpec
                 ImageMF.PFitSpec(self.imgMF, self._err, **kwargs)
-            #except Exception:
-            #    raise (Exception(err_msg), None, sys.exc_info()[2])
-            #handle_obit_err(err_msg)
+            except Exception:
+                raise (Exception(err_msg), None, sys.exc_info()[2])
+            handle_obit_err(err_msg)
 
     @property
     def Desc(self):

--- a/katacomb/katacomb/uv_facade.py
+++ b/katacomb/katacomb/uv_facade.py
@@ -381,6 +381,12 @@ class UVFacade(object):
     def tables(self):
         return self._tables
 
+    @property
+    def tablelist(self):
+        tables = TableList.PGetList(self.uv.TableList, self._err)
+        handle_obit_err("Error getting '%s' table list" % self.name)
+        return tables
+
     def attach_table(self, name, version, **kwargs):
         self._tables[name] = AIPSTable(self.uv, name, version, 'r',
                                        self._err, **kwargs)

--- a/katacomb/katacomb/uv_facade.py
+++ b/katacomb/katacomb/uv_facade.py
@@ -7,6 +7,9 @@ import numpy as np
 
 import TableList
 import UV
+import AIPSDir
+import FITSDir
+import OSystem
 
 from katacomb import (AIPSTable,
                       AIPSHistory,
@@ -315,6 +318,20 @@ class UVFacade(object):
 
         handle_obit_err("Error closing uv file '%s'" % self.name, self._err)
         self._clear_uv()
+
+    @property
+    def exists(self):
+        # Do I exist?
+        exists = False
+        if self.uv.FileType == "FITS":
+            exists = FITSDir.PExist(self.uv.FileName, self.uv.Disk, self._err)
+        elif self.uv.FileType == "AIPS":
+            user = OSystem.PGetAIPSuser()
+            test = AIPSDir.PTestCNO(self.uv.Disk, user, self.uv.Aname,
+                                    self.uv.Aclass, "UV", self.uv.Aseq,
+                                    self._err)
+            exists = test > 0
+        return exists
 
     @property
     def uv(self):


### PR DESCRIPTION
Add 2 improvements to the images generated.

1. The image is computed using a weighted average of the coarse frequency planes rather then fitting a 1st order spectrum per pixel- this removes discontinuities in the continuum images. Retain the spectral index image formed from the pixel fitting in the second plane.

2. Attach the raw SN (self calibration solution) tables and CC (clean component model) table to the output FITS image.