### PR TITLE
Re-instantiate tmp_img after averaging the coarse frequency planes

### DIFF
--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -247,6 +247,10 @@ class PipelineImplementation(Pipeline):
                     tmp_imf = img_factory(aips_path=tmp_img, mode="rw")
                     # nOrder=0 does weighted average of planes
                     tmp_imf.FitMF(nOrder=0)
+                    # Re-instantiate tmp_imf to sync with disk
+                    # TODO: Work out why the FitMF method causes
+                    # the need to do this and fix the problem.
+                    tmp_imf = img_factory(aips_path=tmp_img, mode="r")
                     # Get the first (weighted average plane)
                     img_plane = tmp_imf.GetPlane()
                     # Stick it into the first plane of img.


### PR DESCRIPTION
This stops the resulting image having a blank continuum plane.