### PR TITLE
Truncate AIPS path names to 12 characters

### DIFF
--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -165,7 +165,7 @@ def katdal_uvw(uvw, refwave):
 
 def aips_source_name(name, used=[]):
     """
-    Truncates to length 16, padding with spaces adding
+    Truncates to MAX_AIPS_PATH_LEN, padding with spaces and appending
     repeat number to repeat names.
     """
     return normalise_target_name(name, used, max_length=MAX_AIPS_PATH_LEN)

--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -19,8 +19,8 @@ from katdal.lazy_indexer import DaskLazyIndexer, dask_getitem
 log = logging.getLogger('katacomb')
 
 ONE_DAY_IN_SECONDS = 24*60*60.0
-MAX_AIPS_PATH_LEN = 10
-MAX_AIPS_STRING_LEN = 16
+MAX_AIPS_PATH_LEN = 12
+
 """ Map correlation characters to correlation id """
 CORR_ID_MAP = {('h', 'h'): 0,
                ('v', 'v'): 1,
@@ -168,7 +168,7 @@ def aips_source_name(name, used=[]):
     Truncates to length 16, padding with spaces adding
     repeat number to repeat names.
     """
-    return normalise_target_name(name, used, max_length=MAX_AIPS_STRING_LEN)
+    return normalise_target_name(name, used, max_length=MAX_AIPS_PATH_LEN)
 
 
 def aips_catalogue(katdata, nif):
@@ -234,10 +234,13 @@ def aips_catalogue(katdata, nif):
         # Apparent position
         raa, deca = np.rad2deg(aradec)
 
+        source_name = aips_source_name(t.name, used)
+
         aips_source_data = {
             # Fill in data derived from katpoint target
             'ID. NO.': [aips_i],
-            'SOURCE': [aips_source_name(t.name, used)],
+            # SOURCE keyword requires 16 characters.
+            'SOURCE': [source_name.ljust(16, ' ')],
             'RAEPO': [ra],
             'DECEPO': [dec],
             'RAOBS': [raa],
@@ -319,7 +322,7 @@ def aips_catalogue(katdata, nif):
             'QUAL': [0.0],      # Source Qualifier Number
         }
 
-        used.extend(aips_source_data['SOURCE'])
+        used.append(source_name)
 
         catalogue.append(aips_source_data)
 

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -511,7 +511,8 @@ class TestOnlinePipeline(unittest.TestCase):
 
         # Simulate a '10Jy' source at the phase center
         cat = katpoint.Catalogue()
-        cat.add(katpoint.Target("Alberich, radec, 20.0, -30.0, (856. 1712. 1. 0. 0.)"))
+        cat.add(katpoint.Target(
+            "Alberich lord of the Nibelungs, radec, 20.0, -30.0, (856. 1712. 1. 0. 0.)"))
 
         telstate = TelescopeState()
 


### PR DESCRIPTION
Also- ensure that the UV header 'SOURCE' keyword has 16 characters.

The AIPS file names of imaged targets are derived from their SOURCE
keyword in the input AIPS UV header. Source names were being truncated
to 16 characters, which is the required length of the SOURCE keyword
in an AIPS UV header, via the `normalise_target_name` function. AIPS
file names have a maximum length of 12 characters. While some Obit
tasks can handle this descrepancy (i.e. MFImage will truncate filenames
derived from the SOURCE parameter to 12 characters), others cannot
(i.e. TabCopy) and require that filenames (derived from outName and
inName parameters) are a maximum of 12 characters.

The workaround is to require that all SOURCE header keywords (derived
from katpoint target names) are truncated to 12 characters, then
pad this with spaces up to the 16 characters required. This also ensures
that **unique** filenames will be created when there are multiple
targets with the same first 12 characters in their name. The
output FITS filenames are derived from the katpoint descriptions
and remain unchanged.

Also update a test to include a longer filename for data that is passed
to TabCopy.