### PR TITLE
Fix the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 katsdp.killOldJobs()
 
 katsdp.setDependencies([
-    'ska-sa/katsdpdockerbase/python2',
+    'ska-sa/katsdpdockerbase/master',
     'ska-sa/katpoint/master',
     'ska-sa/katdal/master',
     'ska-sa/katsdpservices/master',

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -1,7 +1,5 @@
 attrs
 astropy == 2.0.3
-backports-abc
-backports.ssl-match-hostname
 beautifulsoup4 == 4.6.0
 botocore
 bs4 == 0.0.1
@@ -45,7 +43,6 @@ requests
 scipy
 toolz
 tornado
-trollius
 webencodings == 0.5.1
 urllib3
 katdal @ git+https://github.com/ska-sa/katdal


### PR DESCRIPTION
- Change dependency on katsdpdockerbase from python2 back to master
- Remove some packages that are no longer needed on Python 3 and
  potentially no longer pinned by katsdpdockerbase.