### PR TITLE
Update requirements to match katsdpdockerbase update

### DIFF
--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -10,14 +10,15 @@ cityhash
 cycler
 dask
 docutils
-fakeredis
-funcsigs == 0.4
+ephem
+funcsigs
 future
 h5py
 html5lib == 1.0.1
 idna
 jmespath
 katversion
+kiwisolver
 llvmlite
 matplotlib
 msgpack

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -11,7 +11,6 @@ cycler
 dask
 docutils
 ephem
-funcsigs
 future
 h5py
 html5lib == 1.0.1


### PR DESCRIPTION
This should be merged together with ska-sa/katsdpdockerbase#46. It may
currently fail to build until that branch is merged.