### PR TITLE
Update PNG rendering

### DIFF
--- a/katacomb/katacomb/__init__.py
+++ b/katacomb/katacomb/__init__.py
@@ -12,7 +12,7 @@ from .util import (task_factory,
                    normalise_target_name,
                    task_defaults)
 
-from .util.image_util import save_image
+from .util.image_util import write_image
 
 from .katdal_adapter import (KatdalAdapter,
                              time_chunked_scans,

--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -156,10 +156,10 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                 center_freq = cf.Desc.Dict['crval'][cf.Desc.Dict['jlocf']] / 1.e6
                 caption = f'{targ.name} Continuum ({center_freq:.0f} MHz)'
                 write_image(in_fitsfile, out_pngfile, width=6500, height=5000,
-                            dpi=10 * DEFAULT_DPI, caption=caption)
+                            dpi=10 * DEFAULT_DPI, caption=caption, facecolor='black')
                 out_pngthumbnail = pjoin(out_dir, out_filebase + TNAIL_EXT)
                 write_image(in_fitsfile, out_pngthumbnail, width=650, height=500,
-                            caption=caption)
+                            caption=caption, facecolor='black')
 
                 # Set up metadata for this target
                 _update_target_metadata(target_metadata, cf, targ, tn,

--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -11,10 +11,11 @@ from katacomb import (uv_factory,
                       katdal_ant_name,
                       obit_image_mf_rms,
                       normalise_target_name,
-                      save_image,
+                      write_image,
                       task_defaults)
 import katacomb.configuration as kc
 from katacomb.katdal_adapter import CORR_ID_MAP
+from katacomb.util.image_util import DEFAULT_DPI
 
 import katpoint
 import numpy as np
@@ -33,6 +34,8 @@ _DROP = {"Table name", "NumFields", "_status"}
 OFILE_SEPARATOR = '_'
 # Default image plane to write as FITS.
 IMG_PLANE = 1
+# Image slice to plot to PNG output
+PNG_SLICE = ('x', 'y', 0, 0)
 # File extensions for FITS, PNG and thumbnails
 FITS_EXT = '.fits'
 PNG_EXT = '.png'
@@ -149,9 +152,14 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                 # Export PNG and a thumbnail PNG
                 log.info('Write PNG image output: %s' % (out_filebase + PNG_EXT))
                 out_pngfile = pjoin(out_dir, out_filebase + PNG_EXT)
-                save_image(cf, out_pngfile, plane=IMG_PLANE)
+                in_fitsfile = pjoin(out_dir, out_filebase + FITS_EXT)
+                center_freq = cf.Desc.Dict['crval'][cf.Desc.Dict['jlocf']] / 1.e6
+                caption = f'{targ.name} Continuum ({center_freq:.0f} MHz)'
+                write_image(in_fitsfile, out_pngfile, width=6500, height=5000,
+                            dpi=10 * DEFAULT_DPI, caption=caption)
                 out_pngthumbnail = pjoin(out_dir, out_filebase + TNAIL_EXT)
-                save_image(cf, out_pngthumbnail, plane=IMG_PLANE, display_size=5., dpi=100)
+                write_image(in_fitsfile, out_pngthumbnail, width=650, height=500,
+                            caption=caption)
 
                 # Set up metadata for this target
                 _update_target_metadata(target_metadata, cf, targ, tn,

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -167,7 +167,7 @@ class TestOnlinePipeline(unittest.TestCase):
         Tests that a run of the online continuum pipeline executes.
         """
 
-        nchan = 16
+        nchan = 32
 
         spws = [{
             'centre_freq': .856e9 + .856e9 / 2.,
@@ -221,7 +221,7 @@ class TestOnlinePipeline(unittest.TestCase):
 
         # Do some baseline averaging for funsies
         uvblavg_params = parse_python_assigns("FOV=1.0; avgFreq=1; "
-                                              "chAvg=8; maxInt=2.0")
+                                              "chAvg=2; maxInt=2.0")
 
         # Run with imaging defaults
         mfimage_params = {'doGPU': False}

--- a/katacomb/katacomb/util/image_util.py
+++ b/katacomb/katacomb/util/image_util.py
@@ -90,7 +90,7 @@ def write_image(input_file, output_file, width=1024, height=768, dpi=DEFAULT_DPI
         # Plot the lot if any axis is completely blanked
         finite_data = np.where(np.isfinite(data))
         bbox = (0, image_width, 0, image_height)
-        if data[finite_data].size > 0:
+        if finite_data[0].size > 0:
             ymin = np.min(finite_data[0])
             ymax = np.max(finite_data[0])
             xmin = np.min(finite_data[1])

--- a/katacomb/katacomb/util/image_util.py
+++ b/katacomb/katacomb/util/image_util.py
@@ -1,65 +1,94 @@
-import numpy as np
-
+import astropy.wcs as wcs
+from astropy import units
+import astropy.io.fits as fits
 from matplotlib import use
-use('Agg', warn=False)
-from matplotlib import pylab as plt  # noqa: E402
+use('Agg', warn=False)  # noqa: E402
+import matplotlib.axes
+from matplotlib import pylab as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import katsdpsigproc.zscale as zscale
 
 
-def save_image(image, filename, plane=1, drop_edge=0.125, cmap='afmhot',
-               display_size=10., dpi=1000):
-    """
-    Write an image plane to a file using imshow with contrast scaling.
+DEFAULT_DPI = 96
+
+
+def _prepare_axes(wcs, width, height, image_width, image_height, dpi, slices, trim):
+    fig = plt.Figure(figsize=(width / dpi, height / dpi), dpi=dpi)
+    ax = fig.add_subplot(projection=wcs, slices=slices)
+    ax.set_xlabel('Right Ascension')
+    ax.set_ylabel('Declination')
+    x_trim, y_trim = image_width * trim, image_height * trim
+    ax.set_xlim(-0.5 + x_trim, image_width - x_trim - 0.5)
+    ax.set_ylim(-0.5 + y_trim, image_height - y_trim - 0.5)
+    return fig, ax
+
+
+def _plot(data, bunit, caption, ax, extent, vmin, vmax):
+    if bunit == 'JY/BEAM':
+        # This is not FITS-standard, but is AIPS standard and is output by AIPS generated FITS images
+        # as well as older versions of katsdpimager
+        unit = units.Jy / units.beam
+    else:
+        unit = units.Unit(bunit)
+    data <<= unit
+    vmin <<= unit
+    vmax <<= unit
+    # If the flux is low, use µJy/beam or mJy/beam to keep scale sane
+    if vmax < 100 * (units.uJy / units.beam):
+        data = data.to(units.uJy / units.beam)
+    elif vmax < 100 * (units.mJy / units.beam):
+        data = data.to(units.mJy / units.beam)
+    vmin = vmin.to(data.unit)
+    vmax = vmax.to(data.unit)
+    if not ax.images:
+        im = ax.imshow(data.value, origin='lower', cmap='afmhot', aspect='equal',
+                       vmin=vmin.value, vmax=vmax.value, extent=extent)
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes('right', pad='3%', size='5%', axes_class=matplotlib.axes.Axes)
+        cbar = ax.get_figure().colorbar(im, cax=cax, orientation='vertical')
+        # simply using data.unit.to_string('unicode') draws an ASCII-art
+        # fraction, which doesn't end up looking very good. But we want
+        # unicode to properly render µJy (rather than uJy).
+        unit_label = (data.unit * units.beam).to_string('unicode') + ' / beam'
+        cbar.set_label(unit_label)
+    else:
+        im = ax.images[0]
+        im.set_data(data)
+        im.set_extent(extent)
+
+    if caption:
+        ax.set_title(f'{caption}')
+
+
+def write_image(input_file, output_file, width=1024, height=768, dpi=DEFAULT_DPI,
+                slices=('x', 'y', 0, 0), trim=0.125, caption=None):
+    """Write an image plane to a file from a single FITS file.
 
     Parameters
     ----------
-    image : :class:`ImageFacade`
-        The image to plot
-    filename : str
-        Disk location of output. Filename extension determins
-        format of the output as for `matplotlib.pylab.savefig`
-    plane : int
-        The image plane to plot
-    drop_edge : float
-        Fraction of pixels on each edge of the image to clip.
-    cmap : str or :class:`matplotlib.colors.Colormap`
-        Matplotlib style colormap to use (passed to `imshow`)
-    display_size : float
-        Size in inches for the `matplotlib.pylab.figure` instance.
+    input_file : str
+        Source FITS file
+    output_file : str
+        Output image file, including extension
+    width, height : int
+        Dimensions of output image
     dpi : int
-        Dots per inch desired for figure.
-        (Passed to `matplotlib.pylab.savefig`)
+        DPI of output image
+    slices : list
+        Choice of image dimensions. Passed to :class:`WCSAxes`
+    trim : float
+        Fraction of pixels on each edge of the image to clip
+    caption : Optional[str]
+        Optional caption to include in the image
     """
 
-    # Get the image array for the desired plane
-    image.GetPlane(None, [plane, 1, 1, 1, 1])
-    imagedata = image.np_farray
-
-    xpix, ypix = imagedata.shape
-
-    # Determine amount of image edge to remove
-    x_off = int(xpix * drop_edge)
-    y_off = int(ypix * drop_edge)
-
-    # Cut the image to the desired display size
-    x_keep = slice(x_off, xpix - x_off)
-    y_keep = slice(y_off, ypix - y_off)
-    cutimagedata = imagedata[x_keep, y_keep]
-
-    # Get low and high pixel values to stretch the comormap
-    lowcut, highcut = zscale.zscale(zscale.sample_image(cutimagedata))
-
-    im = plt.figure(figsize=(display_size, display_size))
-
-    # Remove axes and whitespace around edges
-    plt.axis('off')
-    plt.axes([0, 0, 1, 1])
-
-    # Plot the image with the desired colormap and contrast
-    plt.imshow(cutimagedata, cmap=cmap, vmin=lowcut, vmax=highcut,
-               aspect='equal', origin='lower', interpolation='nearest')
-
-    # Save to filename at the desired dpi
-    plt.savefig(filename, dpi=dpi)
-    plt.close(im)
+    with fits.open(input_file) as hdus:
+        ax_select = tuple(slice(None) if s in ('x', 'y') else s for s in slices[::-1])
+        data = hdus[0].data[ax_select]
+        vmin, vmax = zscale.zscale(zscale.sample_image(data))
+        image_height, image_width = data.shape
+        fig, ax = _prepare_axes(wcs.WCS(hdus[0]), width, height, image_width, image_height, dpi, slices, trim)
+        bunit = hdus[0].header['BUNIT']
+        _plot(data, bunit, caption, ax, None, vmin, vmax)
+        fig.savefig(output_file)

--- a/katacomb/katacomb/util/image_util.py
+++ b/katacomb/katacomb/util/image_util.py
@@ -91,8 +91,10 @@ def write_image(input_file, output_file, width=1024, height=768, dpi=DEFAULT_DPI
         finite_data = np.where(np.isfinite(data))
         bbox = (0, image_width, 0, image_height)
         if data[finite_data].size > 0:
-            ymax, xmax = np.max(finite_data, axis=1)
-            ymin, xmin = np.min(finite_data, axis=1)
+            ymin = np.min(finite_data[0])
+            ymax = np.max(finite_data[0])
+            xmin = np.min(finite_data[1])
+            xmax = np.max(finite_data[1])
             bbox = (xmin, xmax, ymin, ymax)
         fig, ax = _prepare_axes(wcs.WCS(hdus[0]), width, height, image_width, image_height, dpi, slices, bbox)
         bunit = hdus[0].header['BUNIT']

--- a/katacomb/katacomb/util/image_util.py
+++ b/katacomb/katacomb/util/image_util.py
@@ -19,8 +19,8 @@ def _prepare_axes(wcs, width, height, image_width, image_height, dpi, slices, bb
     ax = fig.add_subplot(projection=wcs, slices=slices)
     ax.set_xlabel('Right Ascension')
     ax.set_ylabel('Declination')
-    ax.set_xlim(-0.5 + bbox[0], bbox[1] - 0.5)
-    ax.set_ylim(-0.5 + bbox[2], bbox[3] - 0.5)
+    ax.set_xlim(-0.5 + bbox[0], bbox[1] + 0.5)
+    ax.set_ylim(-0.5 + bbox[2], bbox[3] + 0.5)
     return fig, ax
 
 

--- a/katacomb/katacomb/util/image_util.py
+++ b/katacomb/katacomb/util/image_util.py
@@ -2,165 +2,15 @@ import numpy as np
 
 from matplotlib import use
 use('Agg', warn=False)
-
 from matplotlib import pylab as plt  # noqa: E402
 
-
-def zscale(image, maxsamples=100000, contrast=0.02, stretch=5.0,
-           sigma_rej=3.0, max_iter=500, max_reject=0.1, min_npix=5):
-    """
-    A python implementation of the IRAF/ds9 zscale algorithm
-    for determining maximum and minumum image values for a given
-    contrast. This is used to scale a colourmap applied to FITS
-    images when saving to alternative image formats or for on
-    screen display.
-
-    A description of the zscale algorithm can be found here:
-    https://iraf.net/forum/viewtopic.php?showtopic=134139
-
-    This implementation has a few minor changes from IRAF:
-        1: Don't default to the full data range if iterations
-           reject `max_reject` samples- use the range determined
-           on the final iteration instead.
-        2: Use the masked set of samples to work out the image
-           median. The masked data should give an answer without
-           including source/artefact contributions to the pixel
-           distribution.
-        3: Addition of a stretch factor to scale the derived
-           minimum and maximum. This is applicable to radio
-           images, where negative pixel values can cause the
-           vanilla IRAF algorithm to display too much of the
-           background rumble.
-
-    Parameters
-    ----------
-    image : array
-        Input array of pixel values. shape(numxpix, numypix)
-    maxsamples : int
-        Number of elements to subsample the input image into.
-        This improves the speed of the algorithm.
-    contrast : float
-        The scaling factor (between 0 and 1) for determining
-        the returnes minimum and maximum value. Larger values
-        decrease the difference between them.
-    stretch : float
-        Scale factor by which to scale the contrasted gradient.
-        The minimum value is derived from gradient / stretch
-        and the maximum value from gradient * stretch.
-    sigma_rej: float
-        Multiple of standard deviation to reject outliers
-        while iterating.
-    max_iter: int
-        Maximum number of iterations.
-    max_reject: float
-        Stop iterating if number of pixels left is less than
-        `max_reject`*npix.
-    min_npix: int
-        Hard limit on the minimum number of pixels allowed in
-        the sampled input and after rejection.
-    """
-
-    # Figure out which pixels to use for the zscale algorithm
-    # Returns the 1-d array samples
-    nx, ny = image.shape
-    stride = int(max(1., np.sqrt(nx * ny / float(maxsamples))))
-    samples = image[::stride, ::stride].flatten()
-    # Remove blanked pixels
-    samples = samples[np.isfinite(samples)]
-    # Force the maximum number of samples
-    samples = samples[:maxsamples]
-
-    samples.sort()
-    npix = len(samples)
-    zmin = samples[0]
-    zmax = samples[-1]
-
-    # Minimum number of pixels allowed
-    minpix = max(min_npix, int(npix * max_reject))
-
-    # Grow rejected pixels in each iteration
-    ngrow = max(1, int(npix * 0.01))
-
-    if npix <= minpix:
-        return zmin, zmax
-
-    # Re-map indices from -1.0 to 1.0
-    # to improve fitting.
-    xscale = 2.0 / (npix - 1)
-    xnorm = np.arange(npix)
-    xnorm = xnorm * xscale - 1.0
-
-    # Set up for iteration
-    ngoodpix = npix
-    last_ngoodpix = npix + 1
-
-    # Mask used in k-sigma clipping.
-    badpix = np.zeros(npix, dtype=np.bool)
-
-    # Iterate, until maximum iteration, too many pixels
-    # rejected or until no change in number of good pixels
-    niter = 0
-    while niter < max_iter and ngoodpix > minpix and ngoodpix < last_ngoodpix:
-        # Fit a line to the remaining pixels
-        good_xnorm = xnorm[~badpix]
-        A = np.vstack((good_xnorm, np.ones(len(good_xnorm)))).T
-        slope, intercept = np.linalg.lstsq(A, samples[~badpix], rcond=None)[0]
-
-        # Subtract fitted line from the full data array
-        fitted = xnorm * slope + intercept
-        flat = samples - fitted
-
-        # Compute the k-sigma rejection threshold
-        sigma = np.std(flat[~badpix])
-        threshold = sigma * sigma_rej
-
-        # Detect and reject pixels further than k*sigma from the fitted line
-        badpix = np.abs(flat) > threshold
-
-        # Compute number of remaining pixels before convolution
-        last_ngoodpix = ngoodpix
-        ngoodpix = np.sum(~badpix)
-
-        # Convolve with a kernel of length ngrow
-        kernel = np.ones(ngrow, dtype=np.bool)
-        badpix = np.convolve(badpix, kernel, mode='same')
-
-        niter += 1
-
-    # Transform the slope back to the X range [0:npix-1]
-    slope = slope * xscale
-
-    # Apply contrast scaling
-    if contrast > 0:
-        slope = slope / contrast
-
-    # Stretch the slope
-    slope_hi = slope * stretch
-    slope_low = slope / stretch
-
-    # Median of the remaining samples is close to true
-    # pixel median sans sources/artefacts
-    good_samples = samples[~badpix]
-    median = np.median(good_samples)
-
-    # Find the indices of the median, low and high pixels
-    median_pixel = np.searchsorted(samples, median)
-    low_pixel = np.searchsorted(samples, good_samples[0])
-    hi_pixel = np.searchsorted(samples, good_samples[-1])
-
-    # Derive scale limits from slope_low and slope_hi
-    z1 = max(zmin, median - (median_pixel - low_pixel) * slope_low)
-    z2 = min(zmax, median + (hi_pixel - median_pixel) * slope_hi)
-
-    return z1, z2
+import katsdpsigproc.zscale as zscale
 
 
 def save_image(image, filename, plane=1, drop_edge=0.125, cmap='afmhot',
-               display_size=10., dpi=1000, **kwargs):
+               display_size=10., dpi=1000):
     """
     Write an image plane to a file using imshow with contrast scaling.
-    Input kwargs are passed to the zscale function for the contrast
-    scaling.
 
     Parameters
     ----------
@@ -198,7 +48,7 @@ def save_image(image, filename, plane=1, drop_edge=0.125, cmap='afmhot',
     cutimagedata = imagedata[x_keep, y_keep]
 
     # Get low and high pixel values to stretch the comormap
-    lowcut, highcut = zscale(cutimagedata, **kwargs)
+    lowcut, highcut = zscale.zscale(zscale.sample_image(cutimagedata))
 
     im = plt.figure(figsize=(display_size, display_size))
 

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -1,38 +1,37 @@
+appdirs
+astropy == 3.1.2
 attrs
-astropy == 2.0.3
-beautifulsoup4 == 4.6.0
 botocore
-bs4 == 0.0.1
 cerberus == 1.1
 certifi
 chardet
 cityhash
 cycler
 dask
+decorator
 docutils
 ephem
 future
 h5py
-html5lib == 1.0.1
 idna
 jmespath
 katversion
 kiwisolver
 llvmlite
+mako
+markupsafe
 matplotlib
 msgpack
 netifaces
 nose
 numba
 numpy
-pluggy == 0.6.0
+pandas
 pretty-py3 == 0.2.4
-py == 1.5.2
 pyephem
 pygelf
 pyjwt
 pyparsing
-pytest == 3.3.2
 python-dateutil
 python-lzf
 pytz
@@ -43,9 +42,11 @@ requests
 scipy
 toolz
 tornado
-webencodings == 0.5.1
+typing-extensions
 urllib3
+
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
-katsdpservices @ git+https://github.com/ska-sa/katsdpservices
+katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
+katsdpservices @ git+https://github.com/ska-sa/katsdpservices

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -47,6 +47,6 @@ urllib3
 
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
+katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
-katsdpservices @ git+https://github.com/ska-sa/katsdpservices

--- a/katacomb/scripts/continuum_pipeline.py
+++ b/katacomb/scripts/continuum_pipeline.py
@@ -160,9 +160,9 @@ def _infer_defaults_from_katdal(katds):
     if refant is not None:
         mfimage_params['refAnt'] = aips_ant_nr(refant)
 
-    #Get the total observed time (t_obs) currently selected in the
-    #kat_adapter and set the MFImage:maxRealtime parameter to
-    #max(mintime, t_obs*(1. + extra)).
+    # Get the total observed time (t_obs) currently selected in the
+    # kat_adapter and set the MFImage:maxRealtime parameter to
+    # max(mintime, t_obs*(1. + extra)).
     t_obs = katds.shape[0] * katds.dump_period
     maxRealtime = max(MINRUNTIME, t_obs * (1. + RUNTIME_PAD))
     mfimage_params['maxRealtime'] = float(maxRealtime)


### PR DESCRIPTION
Use the zscale algorithm from katsdpsigproc now that it has moved there. The rest is largely a cut-and-paste job from `render.py` in katsdpimager. The commit messages describe the changes I needed to make for continuum images.

@bmerry, as we discussed, this (or a variant) could go somewhere else where both katsdpimager and katsdpcontim can import it. I suspect zscale could also leave katsdpsigproc and join it as well. As such this PR is really just an indication of how things will work for the continuum case so we can identify whether or not the implementations have enough in common to move things somewhere else. I'll put a 'do not merge' on this while we work that out.