### PR TITLE
Update FITS headers

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -106,9 +106,26 @@ def _metadata(katds, cb_id, target_metadata):
     return metadata
 
 
+def _make_pngs(out_dir, out_filebase, caption):
+    """Export FITS file in filebase to png and thumbnail in same location."""
+    out_pngfile = pjoin(out_dir, out_filebase + PNG_EXT)
+    in_fitsfile = pjoin(out_dir, out_filebase + FITS_EXT)
+    katsdpimageutils.render.write_image(
+        in_fitsfile, out_pngfile,
+        width=6500, height=5000,
+        dpi=10 * katsdpimageutils.render.DEFAULT_DPI,
+        caption=caption, facecolor='black'
+    )
+    out_pngthumbnail = pjoin(out_dir, out_filebase + TNAIL_EXT)
+    katsdpimageutils.render.write_image(
+        in_fitsfile, out_pngthumbnail,
+        width=650, height=500,
+        caption=caption, facecolor='black'
+    )
+
+
 def export_images(clean_files, target_indices, disk, kat_adapter):
-    """
-    Write out FITS, PNG and metadata.json files for each image in clean_files.
+    """Write out FITS, PNG and metadata.json files for each image in clean_files.
 
     Parameters
     ----------
@@ -149,22 +166,9 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
 
                 # Export PNG and a thumbnail PNG
                 log.info('Write PNG image output: %s' % (out_filebase + PNG_EXT))
-                out_pngfile = pjoin(out_dir, out_filebase + PNG_EXT)
-                in_fitsfile = pjoin(out_dir, out_filebase + FITS_EXT)
                 center_freq = cf.Desc.Dict['crval'][cf.Desc.Dict['jlocf']] / 1.e6
                 caption = f'{targ.name} Continuum ({center_freq:.0f} MHz)'
-                katsdpimageutils.render.write_image(
-                    in_fitsfile, out_pngfile,
-                    width=6500, height=5000,
-                    dpi=10 * katsdpimageutils.render.DEFAULT_DPI,
-                    caption=caption, facecolor='black'
-                )
-                out_pngthumbnail = pjoin(out_dir, out_filebase + TNAIL_EXT)
-                katsdpimageutils.render.write_image(
-                    in_fitsfile, out_pngthumbnail,
-                    width=650, height=500,
-                    caption=caption, facecolor='black'
-                )
+                _make_pngs(out_dir, out_filebase, caption)
 
                 # Set up metadata for this target
                 _update_target_metadata(target_metadata, cf, targ, tn,

--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -136,7 +136,7 @@ def _update_fits_header(fitsfile, clean_file):
 
         # Add BMAJ, BMIN, BPA keywords (Set to -1 if unavailable)
         fh['BMAJ'] = (dd.get('beamMaj', -1), 'Beam major axis FWHM (deg)')
-        fh['BMIN'] = (dd.get('beamMin', -1), 'Beam major axis FWHM (deg)')
+        fh['BMIN'] = (dd.get('beamMin', -1), 'Beam minor axis FWHM (deg)')
         fh['BPA'] = (dd.get('beamPA', -1), 'Beam position angle (deg)')
 
         # Correct BUNIT to FITS standard v4.0 (So that astropy can read it)

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -4,6 +4,8 @@ import unittest
 from functools import partial
 
 
+import astropy.io.fits as fits
+from nose.tools import assert_equal, assert_in
 import numpy as np
 from scipy import constants
 
@@ -60,6 +62,18 @@ def weights(dataset):
 
 def flags(dataset):
     return np.zeros(dataset.shape, dtype=np.bool)
+
+
+def _check_fits_headers(filepath):
+    with fits.open(filepath) as ff:
+        fh = ff[0].header
+        # Ensure BUNIT is in correct format
+        assert_equal('Jy/beam', fh['BUNIT'])
+        # Its overkill to check the actual values of
+        # BMAJ, BMIN, BPA so just check they are there
+        assert_in('BMAJ', fh)
+        assert_in('BMIN', fh)
+        assert_in('BPA', fh)
 
 
 class TestOfflinePipeline(unittest.TestCase):
@@ -133,6 +147,7 @@ class TestOfflinePipeline(unittest.TestCase):
         filename = '_'.join(filter(None, out_strings)) + '.fits'
         filepath = os.path.join(fits_area, filename)
         assert os.path.isfile(filepath)
+        _check_fits_headers(filepath)
 
         # Remove the tmp/FITS dir
         shutil.rmtree(fits_area)
@@ -155,6 +170,7 @@ class TestOfflinePipeline(unittest.TestCase):
         pipeline.execute()
 
         assert os.path.isfile(filepath)
+        _check_fits_headers(filepath)
 
         # Remove FITS temporary area
         shutil.rmtree(fits_area)
@@ -259,6 +275,7 @@ class TestOnlinePipeline(unittest.TestCase):
             filename = '_'.join(filter(None, out_strings)) + '.fits'
             filepath = os.path.join(fits_area, filename)
             assert os.path.isfile(filepath)
+            _check_fits_headers(filepath)
 
         # Remove the tmp/FITS dir
         shutil.rmtree(fits_area)


### PR DESCRIPTION
Add BMAJ, BMIN, BPA keywords to FITS headers so that external software knows about the CLEAN beam.

Also change BUNIT to 'Jy/beam' (FITS v4.0 standard) from 'JY/BEAM' (AIPS standard). This stops astropy from complaining.
