### PR TITLE
Offline imager updates

### DIFF
--- a/katacomb/katacomb/conf/mfimage.yaml
+++ b/katacomb/katacomb/conf/mfimage.yaml
@@ -32,8 +32,6 @@ minFluxASC: 0.01            # Min. peak A&P self cal (Jy)
 solAInt: 2.0                # A&P SC Solution interval (min)
 solAType: 'L1'              # A&P SC Soln. Type: '  ', 'L1'
 solAMode: 'A&P'             # A&P SC Soln. Mode:'A&P', 'P', 'P!A'
-refAnt: 0                   # SC Reference antenna
 Reuse: 20.0                 # Number of sigma to reuse CCs
 doGPU: True                 # Use GPU predict
 minFList: [0.0001]          # Minimum flux density to CLEAN per Self-cal cycle after first
-maxRealtime: 21600.0        # Wall time after which MFImage will begin to shut down

--- a/katacomb/katacomb/conf/uvblavg.yaml
+++ b/katacomb/katacomb/conf/uvblavg.yaml
@@ -2,5 +2,3 @@
 FOV: 1.0         # Field of view (deg)
 maxInt: 1.0      # Maximum integration (min)
 maxFact: 1.01    # Maximum time smearing factor
-avgFreq: 1       # Frequency averaging control
-chAvg: 4         # Number of chan. to average.


### PR DESCRIPTION
Get the cal reference antenna if it is available and switch off the max Wall time in offline mode.

Any can be overridden by a user supplied .yaml or command line arguments.