### PR TITLE
Expand outlier fields

### DIFF
--- a/katacomb/katacomb/conf/mfimage.yaml
+++ b/katacomb/katacomb/conf/mfimage.yaml
@@ -17,6 +17,7 @@ CatDisk: 1                  # Catalog FITS disk number
 OutlierDist: 2.5            # Maximum distance to add outliers (deg)
 OutlierFlux: 0.005          # Minimum estimated outlier flux density (Jy)
 OutlierSI: -0.7             # Spectral index to estimate flux density
+OutlierSize: 200            # Size in pixels of outlier fields
 minFlux: 0.001              # Minimum Clean component (Jy)
 Niter: 40000                # Maximum # of I CLEAN comp.
 autoCen: 1.e+25             # Auto center min flux density

--- a/katacomb/katacomb/conf/mfimage_MKAT.yaml
+++ b/katacomb/katacomb/conf/mfimage_MKAT.yaml
@@ -25,7 +25,7 @@ PBCor: False                # Apply Frequency PB Corr?
 antSize: 13.5               # Diameter of ant. for PBCor (m)
 maxPSCLoop: 2               # Max. number of phase selfcal loops
 minFluxPSC: 0.0002          # Min. peak phase self cal (Jy)
-solPInt: 0.5                # phase SC Solution interval (min)
+solPInt: 1.0                # phase SC Solution interval (min)
 solPType: 'L1'              # phase SC Soln. Type: '  ', 'L1'
 solPMode: 'P'               # phase SC Soln. Mode:'A&P', 'P', 'P!A','DELA'
 maxASCLoop: 0               # Max. number of amp&ph selfcal loops

--- a/katacomb/katacomb/conf/mfimage_MKAT.yaml
+++ b/katacomb/katacomb/conf/mfimage_MKAT.yaml
@@ -17,6 +17,7 @@ CatDisk: 1                  # Catalog FITS disk number
 OutlierDist: 2.5            # Maximum distance to add outliers (deg)
 OutlierFlux: 0.005          # Minimum estimated outlier flux density (Jy)
 OutlierSI: -0.7             # Spectral index to estimate flux density
+OutlierSize: 200            # Size in pixels of outlier fields
 minFlux: 0.001              # Minimum Clean component (Jy)
 Niter: 40000                # Maximum # of I CLEAN comp.
 autoCen: 1.e+25             # Auto center min flux density

--- a/katacomb/katacomb/conf/uvblavg_MKAT.yaml
+++ b/katacomb/katacomb/conf/uvblavg_MKAT.yaml
@@ -1,6 +1,6 @@
 # Default options for UVBlAvg
 FOV: 1.0         # Field of view (deg)
-maxInt: 0.5      # Maximum integration (min)
+maxInt: 1.0      # Maximum integration (min)
                  # (Should always be less than the self calibration
                  # interval (solPInt and solAInt) in MFImage parameters)
 maxFact: 1.01    # Maximum time smearing factor

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -756,7 +756,7 @@ class OnlinePipeline(KatdalPipelineImplementation):
 
         # Use highest numbered FITS disk for FITS output.
         self.odisk = len(kc.get_config()['fitsdirs'])
-        self.prtlv = 1
+        self.prtlv = 2
         self.disk = 1
 
     def __enter__(self):


### PR DESCRIPTION
Increase the diameter of the outlier facets put on SUMSS source positions to 200 pixels. This ensures that any complex structure missed in the SUMSS catalogue is covered by the image grid and can be deconvolved more accurately.

Also increase the maximum interval for baseline dependent averaging to 1 minute. From testing, this makes a typical visibility dataset about 15% smaller and the imager run about 10% faster. This requires that the self-calibration interval be increased to 1 minute as well. I've tested this change on a number of datasets and the increase has no discernible effect on the resulting images.

Finally, make MFImage a bit more chatty by increasing its log level from 1 to 2 (out of 5).