### PR TITLE
Improve solution export

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -290,7 +290,7 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
                            ts=katdal_timestamps(timestamp, kat_adapter.midnight))
 
                 # Only try and export amp+phase solutions if we expect them
-                if apSN ==0:
+                if apSN == 0:
                     continue
                 apSN_get = min(max_sn, pSN + apSN)
                 # There should be more AIPS SN tables than the requested phase-only

--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -181,14 +181,14 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                 out_strings = [cb_id, ap.label, tn, ap.aclass]
                 out_filebase = OFILE_SEPARATOR.join(filter(None, out_strings))
 
-                log.info('Write FITS image output: %s' % (out_filebase + FITS_EXT))
+                log.info('Write FITS image output: %s', out_filebase + FITS_EXT)
                 cf.writefits(disk, out_filebase + FITS_EXT)
 
                 # Correct values in output FITS header
                 _update_fits_header(pjoin(out_dir, out_filebase + FITS_EXT), cf)
 
                 # Export PNG and a thumbnail PNG
-                log.info('Write PNG image output: %s' % (out_filebase + PNG_EXT))
+                log.info('Write PNG image output: %s', out_filebase + PNG_EXT)
                 center_freq = cf.Desc.Dict['crval'][cf.Desc.Dict['jlocf']] / 1.e6
                 caption = f'{targ.name} Continuum ({center_freq:.0f} MHz)'
                 _make_pngs(out_dir, out_filebase, caption)
@@ -205,7 +205,7 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
     try:
         metadata = _metadata(kat_adapter.katdal, cb_id, target_metadata)
         metadata_file = pjoin(out_dir, METADATA_JSON)
-        log.info('Write metadata JSON: %s' % (METADATA_JSON))
+        log.info('Write metadata JSON: %s', METADATA_JSON)
         with open(metadata_file, 'w') as meta:
             json.dump(metadata, meta)
     except Exception as e:
@@ -271,7 +271,7 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
     for si, uv_file in enumerate(uv_files):
         try:
             with uv_factory(aips_path=uv_file, mode='r') as uvf:
-                log.info('Extracting self-calibration solutions from %s' % uv_file)
+                log.info('Extracting self-calibration solutions from %s', uv_file)
                 sn_versions = [table[0] for table in uvf.tablelist if table[1] == 'AIPS SN']
                 max_sn = max(sn_versions, default=0)
                 # Make sure we have a sequential integer sequence of SN table versions
@@ -279,7 +279,7 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
                 pSN_get = min(max_sn, pSN)
                 if pSN_get == 0:
                     raise ValueError('No self-calibration solutions available')
-                log.info('Extracting phase only self-calibration from AIPS SN: %d' % (pSN_get))
+                log.info('Extracting phase only self-calibration from AIPS SN: %d', pSN_get)
                 uvf.attach_table("AIPS SN", pSN_get)
                 sntab = uvf.tables["AIPS SN"]
                 # Only export dual-pol solutions
@@ -297,7 +297,7 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
                 # self-cal cycles (in pSN) for there to be amp+phase solutions to export
                 if apSN_get <= pSN:
                     raise ValueError('No amp+phase self-calibration solutions available')
-                log.info('Extracting amp+phase self-calibration from AIPS SN: %d' % apSN_get)
+                log.info('Extracting amp+phase self-calibration from AIPS SN: %d', apSN_get)
                 uvf.attach_table("AIPS SN", apSN_get)
                 sntab = uvf.tables["AIPS SN"]
                 for timestamp, gain in zip(*_massage_gains(sntab, ant_ordering)):

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -217,7 +217,7 @@ class PipelineImplementation(Pipeline):
         # Finally, override with default parameters
         mfimage_kwargs.update(self.mfimage_params)
 
-        log.info("MFImage arguments %s" % pretty(mfimage_kwargs))
+        log.info("MFImage arguments %s", pretty(mfimage_kwargs))
 
         mfimage = task_factory("MFImage", **mfimage_kwargs)
         # Send stdout from the task to the log
@@ -649,7 +649,7 @@ class KatdalPipelineImplementation(PipelineImplementation):
                                                           merge_uvf, blavg_uvf,
                                                           nx_row)
             else:
-                log.warn("No visibilities to merge for scan %d" % (si))
+                log.warn("No visibilities to merge for scan %d", si)
 
             # Remove scan once merged
             if 'scans' in self.clobber:
@@ -899,8 +899,8 @@ class KatdalOfflinePipeline(KatdalPipelineImplementation):
             else:
                 # Get the AIPS entry of the UV data to reuse
                 self.uv_merge_path = uv_mp.copy(seq=hiseq)
-                log.info("Re-using UV data in '%s' from AIPS disk: '%s'" %
-                         (self.uv_merge_path, kc.get_config()['aipsdirs'][self.disk - 1][-1]))
+                log.info("Re-using UV data in '%s' from AIPS disk: '%s'",
+                         self.uv_merge_path, kc.get_config()['aipsdirs'][self.disk - 1][-1])
         else:
             self._export_and_merge_scans()
         if "merge" in self.clobber:

--- a/katacomb/katacomb/img_facade.py
+++ b/katacomb/katacomb/img_facade.py
@@ -345,7 +345,7 @@ class ImageFacade(object):
         try:
             self._requireObitImageMF()
         except ValueError:
-            log.warn("%s is not an ImageMF." % self.name)
+            log.warn("%s is not an ImageMF.", self.name)
             imgMF = None
         else:
             imgMF = open_img(self._aips_path, mode=self.mode, MF=True)

--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -1174,8 +1174,8 @@ def time_chunked_scans(kat_adapter, time_step=4):
 
     if vis_size_estimate > EIGHT_GB:
         log.warn("Visibility chunk '%s' is greater than '%s'. "
-                 "Check that sufficient memory is available"
-                 % (fmt_bytes(vis_size_estimate), fmt_bytes(EIGHT_GB)))
+                 "Check that sufficient memory is available",
+                 fmt_bytes(vis_size_estimate), fmt_bytes(EIGHT_GB))
 
     # Get some memory to hold reorganised visibilities
     out_vis = np.empty(out_vis_shape, dtype=kat_adapter.uv_vis.dtype)

--- a/katacomb/katacomb/obit_context.py
+++ b/katacomb/katacomb/obit_context.py
@@ -3,6 +3,7 @@ import logging
 from contextlib import contextmanager
 
 import AIPS
+import AIPSDir
 import ObitTalkUtil
 
 import OErr
@@ -55,6 +56,14 @@ class ObitContext(object):
         """
         Shutdown the Obit System, logging any errors on the error stack
         """
+
+        # Remove defined AIPS & FITS dirs from environment to prevent
+        # overloading the list of defined disks when multiple Obit
+        # environments are constructed in a single python session
+        # (eg. during the unit tests).
+        AIPS.AIPS.disks = [None]
+        AIPSDir.AIPSdisks = []
+
         if self.err.isErr:
             OErr.printErr(self.err)
 

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -582,7 +582,7 @@ class TestOnlinePipeline(unittest.TestCase):
             mfimage_parms = {'maxPSCLoop': 2,
                              'maxASCLoop': 2}
             export_calibration_solutions([ap], ka, mfimage_parms, ts)
-            # Should have solns from SN:4 in 'product_GPHASE'
+            # Should have no solutions in 'product_GPHASE'
             # and no solutions in 'product_GAMP_PHASE'
             self.assertNotIn(P_telstate, ts.keys())
             self.assertNotIn(AP_telstate, ts.keys())

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -462,7 +462,7 @@ def normalise_target_name(name, used=[], max_length=None):
         # If the length of i_name is greater than ml
         # just warn and revert to straight append
         if len(i_name) >= ml:
-            log.warn('Too many repetitions of name %s.' % name)
+            log.warn('Too many repetitions of name %s.', name)
             t_name = name
         o_name = ''.join(filter(None, [t_name, i_name]))
         return '{:{ml}.{ml}}'.format(o_name, ml=ml)
@@ -504,7 +504,7 @@ def apply_user_mask(kat_ds, mask_file):
         kat_ds._corrected.flags = da.bitwise_or(kat_ds._corrected.flags, mask)
         # Ensure mask is applied by resetting selection
         kat_ds.select()
-        log.info("Applying channel mask from: '%s'" % (mask_file))
+        log.info("Applying channel mask from: '%s'", mask_file)
     except Exception:
-        log.exception('Unable to apply supplied mask file from: %s' % (mask_file))
+        log.exception('Unable to apply supplied mask file from: %s', mask_file)
         raise

--- a/katacomb/scripts/continuum_image.py
+++ b/katacomb/scripts/continuum_image.py
@@ -160,7 +160,7 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     configure_logging(args)
-    log.info(f"Reading data with applycal={args.applycal}")
+    log.info("Reading data with applycal=%s", args.applycal)
     katdata = katdal.open(args.katdata, applycal=args.applycal, **args.open_args)
 
     # Apply the supplied mask to the flags
@@ -210,7 +210,7 @@ def main():
         # Set up AIPS disk from specified directory
         if os.path.exists(args.reuse):
             aipsdirs = [(None, args.reuse)]
-            log.info('Re-using AIPS data area: %s' % (aipsdirs[0][1]))
+            log.info('Re-using AIPS data area: %s', aipsdirs[0][1])
             reuse = True
         else:
             msg = "AIPS disk at '%s' does not exist." % (args.reuse)
@@ -219,7 +219,7 @@ def main():
     else:
         # Set up aipsdisk configuration from args.workdir
         aipsdirs = [(None, os.path.join(args.workdir, capture_block_id + '_aipsdisk'))]
-        log.info('Using AIPS data area: %s' % (aipsdirs[0][1]))
+        log.info('Using AIPS data area: %s', aipsdirs[0][1])
         reuse = False
 
     # Set up output configuration from args.outputdir
@@ -227,7 +227,7 @@ def main():
 
     # Append outputdir to fitsdirs
     fitsdirs += [(None, args.outputdir)]
-    log.info('Using output data area: %s' % (args.outputdir))
+    log.info('Using output data area: %s', args.outputdir)
 
     kc.set_config(aipsdirs=aipsdirs, fitsdirs=fitsdirs,
                   output_id='', cb_id=capture_block_id)

--- a/katacomb/scripts/continuum_pipeline.py
+++ b/katacomb/scripts/continuum_pipeline.py
@@ -206,7 +206,7 @@ def main():
         aipsdirs = [(None, pjoin(args.workdir, args.capture_block_id + '_aipsdisk'))]
     else:
         aipsdirs = dc['aipsdirs']
-    log.info('Using AIPS data area: %s' % (aipsdirs[0][1]))
+    log.info('Using AIPS data area: %s', aipsdirs[0][1])
 
     # Set up output configuration from args.outputdir
     fitsdirs = dc['fitsdirs']
@@ -221,7 +221,7 @@ def main():
     # highest numbered fits disk so we ensure that is the case
     # here.
     fitsdirs += [(None, work_outputdir)]
-    log.info('Using output data area: %s' % (outputdir))
+    log.info('Using output data area: %s', outputdir)
 
     kc.set_config(aipsdirs=aipsdirs, fitsdirs=fitsdirs)
 


### PR DESCRIPTION
In the event that the imager times out before the self-calibration cycles are complete, make sure that calibration solutions that are available are still exported.

Details are in the commit messages.