### PR TITLE
Return products

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -157,6 +157,11 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
         FITS disk number to write to
     kat_adapter : :class:`KatdalAdapter`
         Katdal Adapter
+
+    Returns
+    -------
+    dict
+        Metadata dictionary for imaged products
     """
 
     target_metadata = {}
@@ -183,7 +188,6 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
 
                 log.info('Write FITS image output: %s', out_filebase + FITS_EXT)
                 cf.writefits(disk, out_filebase + FITS_EXT)
-
                 # Correct values in output FITS header
                 _update_fits_header(pjoin(out_dir, out_filebase + FITS_EXT), cf)
 
@@ -210,6 +214,8 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
             json.dump(metadata, meta)
     except Exception as e:
         log.warn("Creation of %s failed.\n%s", METADATA_JSON, str(e))
+
+    return metadata
 
 
 def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate):

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -152,7 +152,7 @@ class PipelineImplementation(Pipeline):
 
     def execute(self):
         with obit_context(), self as ctx:
-            ctx.execute_implementation()
+            return ctx.execute_implementation()
 
     def _blavg_scan(self, scan_path):
         """
@@ -783,12 +783,13 @@ class OnlinePipeline(KatdalPipelineImplementation):
         for uv, clean in zip(uv_files, clean_files):
             self._attach_SN_tables_to_image(uv, clean)
 
-        export_images(clean_files, target_indices,
-                      self.odisk, self.ka)
+        metadata = export_images(clean_files, target_indices,
+                                 self.odisk, self.ka)
         export_calibration_solutions(uv_files, self.ka,
                                      self.mfimage_params, self.telstate)
         export_clean_components(clean_files, target_indices,
                                 self.ka, self.telstate)
+        return metadata
 
 
 @register_workmode('offline')
@@ -911,5 +912,4 @@ class KatdalOfflinePipeline(KatdalPipelineImplementation):
         for uv, clean in zip(uv_files, clean_files):
             self._attach_SN_tables_to_image(uv, clean)
 
-        export_images(clean_files, target_indices,
-                      self.odisk, self.ka)
+        return export_images(clean_files, target_indices, self.odisk, self.ka)

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -198,8 +198,8 @@ class TestOfflinePipeline(unittest.TestCase):
                                     reuse=True,
                                     clobber=CLOBBER)
 
-        pipeline.execute()
-
+        metadata = pipeline.execute()
+        assert_in(filename, metadata['FITSImageFilename'])
         assert os.path.isfile(filepath)
         _check_fits_headers(filepath)
 
@@ -286,7 +286,7 @@ class TestOnlinePipeline(unittest.TestCase):
                                     uvblavg_params=uvblavg_params,
                                     mfimage_params=mfimage_params)
 
-        pipeline.execute()
+        metadata = pipeline.execute()
 
         # Check that output FITS files exist and have the right names
         # Expected target name in file output for the list of targets
@@ -304,6 +304,7 @@ class TestOnlinePipeline(unittest.TestCase):
         for otarg in sanitised_target_names:
             out_strings = [cb_id, out_id, otarg, IMG_CLASS]
             filename = '_'.join(filter(None, out_strings)) + '.fits'
+            assert_in(filename, metadata['FITSImageFilename'])
             filepath = os.path.join(fits_area, filename)
             assert os.path.isfile(filepath)
             _check_fits_headers(filepath)


### PR DESCRIPTION
Have the `execute` method of both the online and offline `:class:Pipeline` instances return the `metadata` dictionary that was saved by `export_images`. This dictionary contains information that can be subsequently used by modules (e.g. QA reporting) that need pertinent information about the pipeline run results (e.g. FITS image filenames).