### PR TITLE
Update FITS headers to include band and product info.

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -125,7 +125,7 @@ def _make_pngs(out_dir, out_filebase, caption):
     )
 
 
-def _update_fits_header(fitsfile, clean_file):
+def _update_fits_header(fitsfile, clean_file, kat_adapter):
     """Update FITS header keywords to their more common equivalents."""
 
     with fits.open(fitsfile, mode='update') as ff:
@@ -142,6 +142,10 @@ def _update_fits_header(fitsfile, clean_file):
         # Correct BUNIT to FITS standard v4.0 (So that astropy can read it)
         if fh['BUNIT'] == 'JY/BEAM':
             fh['BUNIT'] = ('Jy/beam', fh.comments['BUNIT'])
+
+        # Add BAND keyword
+        sw = kat_adapter._katds.spectral_windows[kat_adapter._katds.spw]
+        fh['BANDCODE'] = sw.band
 
 
 def export_images(clean_files, target_indices, disk, kat_adapter):
@@ -189,7 +193,7 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                 log.info('Write FITS image output: %s', out_filebase + FITS_EXT)
                 cf.writefits(disk, out_filebase + FITS_EXT)
                 # Correct values in output FITS header
-                _update_fits_header(pjoin(out_dir, out_filebase + FITS_EXT), cf)
+                _update_fits_header(pjoin(out_dir, out_filebase + FITS_EXT), cf, kat_adapter)
 
                 # Export PNG and a thumbnail PNG
                 log.info('Write PNG image output: %s', out_filebase + PNG_EXT)

--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -143,7 +143,7 @@ def _update_fits_header(fitsfile, clean_file, kat_adapter):
         if fh['BUNIT'] == 'JY/BEAM':
             fh['BUNIT'] = ('Jy/beam', fh.comments['BUNIT'])
 
-        # Add BAND keyword
+        # Add BANDCODE keyword cf. AIPS Memo 117
         sw = kat_adapter._katds.spectral_windows[kat_adapter._katds.spw]
         fh['BANDCODE'] = sw.band
 

--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -1048,7 +1048,7 @@ class KatdalAdapter(object):
             'epoch': 2000.0,
             'equinox': 2000.0,
             'teles': MEERKAT,
-            'instrume': MEERKAT,
+            'instrume': self._katds.spectral_windows[self._katds.spw].product,
 
             'isort': 'TB',     # Time, Baseline sort order
             'object': 'MULTI',  # Source, this implies multiple sources

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -77,6 +77,8 @@ def _check_fits_headers(filepath):
         assert_in('BMAJ', fh)
         assert_in('BMIN', fh)
         assert_in('BPA', fh)
+        # Ensure output images have a BAND keyword
+        assert_in('BANDCODE', fh)
 
 
 def construct_SN_desc(nif, rows, version=1):


### PR DESCRIPTION
`BANDCODE` is the keyword used in AIPS Memo 117 so I thought I would stick to that. The other change makes sure the `INSTRUME` keyword in the fits header contains the product name (as per spectral images).