### PR TITLE
Update for changes to katsdpimageutils

### DIFF
--- a/katacomb/katacomb/qa_report.py
+++ b/katacomb/katacomb/qa_report.py
@@ -113,7 +113,8 @@ def make_pbeam_images(metadata, in_dir, write_tag):
 
         os.mkdir(pb_dir)
         pbc_path = os.path.join(pb_dir, out_filebase_pb + FITS_EXT)
-        bp, raw_image = pbc.beam_pattern(in_path)
+        bp = pbc.beam_pattern(in_path)
+        raw_image = pbc.read_fits(in_path)
         pbc_image = pbc.primary_beam_correction(bp, raw_image, px_cut=0.1)
         pbc.write_new_fits(pbc_image, in_path, outputFilename=pbc_path)
 

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -22,6 +22,7 @@ scipy
 seaborn == 0.10.1      # for MeerKAT-continuum-validation
 uncertainties == 3.1.4 # for MeerKAT-continuum-validation
 
+katbeam @ git+https://github.com/ska-sa/katbeam  # for katsdpimageutils
 katdal[s3credentials] @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
 katsdpimageutils @ git+https://github.com/ska-sa/katsdpimageutils


### PR DESCRIPTION
The recent merge of https://github.com/ska-sa/katsdpimageutils/pull/10 to master broke katsdpcontim due to adding https://github.com/ska-sa/katbeam as a requirement, and due to a minor change in the interface to the `beam_pattern` function.

This updates things so that it works again.