### PR TITLE
Make 'RMSNoise' in metadata a list

### DIFF
--- a/katacomb/katacomb/qa_report.py
+++ b/katacomb/katacomb/qa_report.py
@@ -82,7 +82,7 @@ def make_image_metadata(metadata, suffix, outdir, i, rname, desc, rmsnoise):
     desc_prefix = meta_suffix['Description'].split(':')[0]
     meta_suffix['Description'] = desc_prefix + f': {desc}'
 
-    meta_suffix['RMSNoise'] = str(rmsnoise)
+    meta_suffix['RMSNoise'] = [str(rmsnoise)]
     write_metadata(meta_suffix, outdir)
 
 


### PR DESCRIPTION
I accidently made it an str(float) and this is causing the metadata validator to fail. Products with this updated RMSNoise therefore won't appear in the archive 