### PR TITLE
SPR1-975 Verify metadata in tests

### DIFF
--- a/katacomb/katacomb/mock_dataset.py
+++ b/katacomb/katacomb/mock_dataset.py
@@ -86,7 +86,7 @@ DEFAULT_METADATA = {
     'description':  'mock observation',
     'experiment_id': 'mock',
     'obs_params': {
-        'sb_id_code': 'MOCK_SBID',
+        'sb_id_code': '20999999-9999',
         'description': 'mock observation',
         'proposal_id': 'MOCK_PID',
         'observer': 'ghost'

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -29,9 +29,11 @@ from katacomb.mock_dataset import (MockDataSet,
                                    DEFAULT_TIMESTAMPS,
                                    ANTENNA_DESCRIPTIONS)
 from katacomb.util import (parse_python_assigns,
-                           setup_aips_disks)
+                           setup_aips_disks,
+                           _validate_metadata)
 from katacomb.uv_facade import uv_factory
 import katacomb.configuration as kc
+
 
 CLOBBER = set(['scans', 'avgscans', 'merge', 'clean', 'mfimage'])
 
@@ -278,7 +280,7 @@ class TestOnlinePipeline(unittest.TestCase):
         # Dummy CB_ID and Product ID and temp fits disk
         fd = kc.get_config()['fitsdirs']
         fd += [(None, '/tmp/FITS')]
-        kc.set_config(output_id='OID', cb_id='CBID', fitsdirs=fd)
+        kc.set_config(output_id='OID', cb_id='9999999999', fitsdirs=fd)
 
         setup_aips_disks()
 
@@ -289,6 +291,8 @@ class TestOnlinePipeline(unittest.TestCase):
                                     mfimage_params=mfimage_params)
 
         metadata = pipeline.execute()
+
+        _validate_metadata(metadata)
 
         # Check that output FITS files exist and have the right names
         # Expected target name in file output for the list of targets

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -5,7 +5,9 @@ import logging
 import os
 import pickle
 import re
+import requests
 import sys
+import warnings
 
 from pretty import pretty
 import yaml
@@ -45,6 +47,23 @@ OBIT_TO_LOG = {
 }
 
 OBIT_LOG_PREAMBLE_LEN = 23
+
+
+VERIFY_METADATA_URL="http://kat-archive.kat.ac.za:8083/products/verify"
+
+
+def _validate_metadata(metadata):
+    """Validate metadata dictionary using VERIFY_METADATA_URL"""
+    try:
+        response = requests.post(VERIFY_METADATA_URL, json={"metadata": metadata})
+    except requests.ConnectionError as e:
+        # If we can't connect to VERIFY_METADATA_URL don't validate
+        warnings.warn(f"{e}\nSkipping metadata verification", RuntimeWarning)
+    else:
+        if response.status_code != 200:
+            # Log the problem if the metadata doesn't validate and raise an HTTPError
+            log.error(response.text)
+            response.raise_for_status()
 
 
 @contextlib.contextmanager

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -49,7 +49,7 @@ OBIT_TO_LOG = {
 OBIT_LOG_PREAMBLE_LEN = 23
 
 
-VERIFY_METADATA_URL="http://kat-archive.kat.ac.za:8083/products/verify"
+VERIFY_METADATA_URL = "http://kat-archive.kat.ac.za:8083/products/verify"
 
 
 def _validate_metadata(metadata):


### PR DESCRIPTION
This checks that the contents of both the FITS and QA `metadata.json` files conform to standards during tests. 

Doing so should prevent a repeat of what happened during our last deployment when data wasn't archived due to an incorrectly formatted metadata keyword.