### PR TITLE
Improve contrast of PNG images.

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -35,6 +35,8 @@ OFILE_SEPARATOR = '_'
 IMG_PLANE = 1
 # Image slice to plot to PNG output
 PNG_SLICE = ('x', 'y', 0, 0)
+# Contrast in zscale for PNG output
+CONTRAST = 0.5
 # File extensions for FITS, PNG and thumbnails
 FITS_EXT = '.fits'
 PNG_EXT = '.png'
@@ -107,7 +109,7 @@ def _metadata(katds, cb_id, target_metadata):
     return metadata
 
 
-def _make_pngs(out_dir, out_filebase, caption):
+def _make_pngs(out_dir, out_filebase, caption, contrast=0.02):
     """Export FITS file in filebase to png and thumbnail in same location."""
     out_pngfile = pjoin(out_dir, out_filebase + PNG_EXT)
     in_fitsfile = pjoin(out_dir, out_filebase + FITS_EXT)
@@ -115,13 +117,15 @@ def _make_pngs(out_dir, out_filebase, caption):
         in_fitsfile, out_pngfile,
         width=6500, height=5000,
         dpi=10 * katsdpimageutils.render.DEFAULT_DPI,
-        caption=caption, facecolor='black'
+        caption=caption, facecolor='black',
+        contrast=contrast
     )
     out_pngthumbnail = pjoin(out_dir, out_filebase + TNAIL_EXT)
     katsdpimageutils.render.write_image(
         in_fitsfile, out_pngthumbnail,
         width=650, height=500,
-        caption=caption, facecolor='black'
+        caption=caption, facecolor='black',
+        contrast=contrast
     )
 
 
@@ -199,7 +203,7 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                 log.info('Write PNG image output: %s', out_filebase + PNG_EXT)
                 center_freq = cf.Desc.Dict['crval'][cf.Desc.Dict['jlocf']] / 1.e6
                 caption = f'{targ.name} Continuum ({center_freq:.0f} MHz)'
-                _make_pngs(out_dir, out_filebase, caption)
+                _make_pngs(out_dir, out_filebase, caption, contrast=CONTRAST)
 
                 # Set up metadata for this target
                 _update_target_metadata(target_metadata, cf, targ, tn,

--- a/katacomb/katacomb/qa_report.py
+++ b/katacomb/katacomb/qa_report.py
@@ -17,6 +17,9 @@ from katacomb.aips_export import _make_pngs, FITS_EXT, PNG_EXT, METADATA_JSON
 
 log = logging.getLogger('katacomb')
 
+# Contrast in zscale for PB image PNG
+PB_CONTRAST = 0.3
+
 
 def _productdir(metadata, base_dir, i, suffix, write_tag):
     target_name = metadata['Targets'][i]
@@ -24,12 +27,12 @@ def _productdir(metadata, base_dir, i, suffix, write_tag):
     return base_dir + f'_{target_name}_{run}{suffix}' + write_tag
 
 
-def _caption_pngs(in_dir, fits_file, target, label):
+def _caption_pngs(in_dir, fits_file, target, label, contrast=0.02):
     """Caption and make PNG files"""
     imghdr = fits.open(os.path.join(in_dir, fits_file + FITS_EXT))[0].header
     center_freq = imghdr['CRVAL3'] / 1e6
     caption = f'{target.name} Continuum ({center_freq:.0f} MHz) ({label})'
-    _make_pngs(in_dir, fits_file, caption)
+    _make_pngs(in_dir, fits_file, caption, contrast=contrast)
 
 
 def _update_metadata_imagedata(metadata, out_filebase, i):
@@ -124,7 +127,7 @@ def make_pbeam_images(metadata, in_dir, write_tag):
         log.info('Write primary beam corrected PNG output: %s',
                  out_filebase_pb + PNG_EXT)
         _caption_pngs(pb_dir, out_filebase_pb,
-                      kat_target, 'PB Corrected')
+                      kat_target, 'PB Corrected', contrast=PB_CONTRAST)
 
 
 class StreamToLogger:


### PR DESCRIPTION
The contrast of the raw and primary beam corrected PNG images output by the pipeline was set to the default value of 0.02 from the zscale algorithm in katsdpimageutils. This results in `vmin` and `vmax` values that are too far from the mean, and the resulting PNGs are too dark to see many features.
This updates the contrast to 0.5 for the raw MFImage output and to 0.3 for the PB corrected image. The mean and rms images are fine with the default value and I've left them unchanged.
The modified contrast makes it easier to see features in the images that make them more useful for QA appraisal.
Some examples of the effect of these changes are shown in JIRA ticket SPR1-1296