### PR TITLE
Decrease maxFBW in MFImage to 4.5% for online S-band.

### DIFF
--- a/katacomb/katacomb/conf/mfimage_MKAT_S.yaml
+++ b/katacomb/katacomb/conf/mfimage_MKAT_S.yaml
@@ -14,7 +14,7 @@
 Stokes: 'I'                 # Stokes to process
 norder: 1                   # Maximum order of spectral terms
 Alpha: 0.0                  # Spectral Index to correct
-maxFBW: 0.05                # Max. fractional sub-band center bandwidth
+maxFBW: 0.045               # Max. fractional sub-band center bandwidth
 FOV: 0.65                   # Radius of field to image (deg)
 xCells: 0.0                 # Image cell spacing in X in asec.
 yCells: 0.0                 # Image cell spacing in Y in asec.


### PR DESCRIPTION
This creates 8 sub-bands during imaging rather than the 6 with maxFBW=5%
and stops an as yet unfixed MFImage bug causing deconvoluton in the second
sub-band to diverge. The change has minimal cost to MFImage runtime.