### PR TITLE
Update single literals to double literals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,11 +141,11 @@ RUN apt-get update && \
 # Set up areas for image/metadata output
 RUN mkdir -p /var/kat/data
 RUN chown -R kat:kat /var/kat
-VOLUME ['/var/kat/data/']
+VOLUME ["/var/kat/data/"]
 
 RUN mkdir /scratch
 RUN chown kat:kat /scratch
-VOLUME ['/scratch']
+VOLUME ["/scratch"]
 
 # Now downgrade to kat
 USER kat


### PR DESCRIPTION
Very small change. The Dockerfile VOLUME command needs double literals after docker-ce upgrade on jenkins build agents.