### PR TITLE
Update narrowband averaging parameters.

### DIFF
--- a/katacomb/katacomb/conf/uvblavg_MKAT_narrow_L.yaml
+++ b/katacomb/katacomb/conf/uvblavg_MKAT_narrow_L.yaml
@@ -13,6 +13,6 @@ FOV: 1.0         # Field of view (deg)
 maxInt: 1.0      # Maximum integration (min)
                  # (Should always be less than the self calibration
                  # interval (solPInt and solAInt) in MFImage parameters)
-maxFact: 1.0    # Maximum time smearing factor
-avgFreq: 1      # Frequency averaging control 
-chAvg: 32       # Number of channels to average
+maxFact: 1.0     # Maximum time smearing factor
+avgFreq: 1       # Frequency averaging control
+chAvg: 4         # Number of channels to average

--- a/katacomb/katacomb/conf/uvblavg_narrow_L.yaml
+++ b/katacomb/katacomb/conf/uvblavg_narrow_L.yaml
@@ -12,5 +12,5 @@
 FOV: 1.25        # Field of view (deg)
 maxInt: 0.5      # Maximum integration (min)
 maxFact: 1.01    # Maximum time smearing factor
-avgFreq: 1       # Averaging channels?
-chAvg: 32         # Assume 32K -> 1K for offline.
+avgFreq: 1       # Frequency averaging control
+chAvg: 128       # Assume 32K -> 256 channels for offline.


### PR DESCRIPTION
This ensures that the the data is averaged to 256 channels before going into the imager by default in both offline and online mode.