### PR TITLE
Move the QA report and PB import from the module to the script level.

### DIFF
--- a/katacomb/katacomb/__init__.py
+++ b/katacomb/katacomb/__init__.py
@@ -36,10 +36,6 @@ from .aips_export import (export_calibration_solutions,
                           export_clean_components,
                           export_images)
 
-from .qa_report import (make_pbeam_images,
-                        make_qa_report,
-                        organise_qa_output)
-
 from .continuum_pipeline import pipeline_factory
 
 # BEGIN VERSION CHECK

--- a/katacomb/katacomb/tests/test_qa.py
+++ b/katacomb/katacomb/tests/test_qa.py
@@ -9,14 +9,16 @@ from astropy.io import fits
 from astropy.modeling import models
 from unittest import mock
 
-from katacomb import (make_pbeam_images, make_qa_report,
-                      normalise_target_name, organise_qa_output)
+from katacomb import normalise_target_name
 from katacomb.aips_export import (_update_target_metadata,
                                   _metadata,
                                   FITS_EXT,
                                   PNG_EXT,
                                   METADATA_JSON)
 from katacomb.mock_dataset import MockDataSet
+from katacomb.qa_report import (make_pbeam_images,
+                                make_qa_report,
+                                organise_qa_output)
 
 HDR_KEYS = {'NAXIS': 4,
             'NAXIS1': 100,

--- a/katacomb/scripts/continuum_pipeline.py
+++ b/katacomb/scripts/continuum_pipeline.py
@@ -24,15 +24,16 @@ from katsdpservices import setup_logging
 from katsdptelstate import TelescopeState
 
 import katacomb.configuration as kc
-from katacomb import (pipeline_factory, aips_ant_nr,
-                      make_pbeam_images, make_qa_report,
-                      organise_qa_output)
+from katacomb import pipeline_factory, aips_ant_nr
 from katacomb.util import (parse_python_assigns,
                            recursive_merge,
                            get_and_merge_args,
                            log_exception,
                            post_process_args,
                            setup_aips_disks)
+from katacomb.qa_report import (make_pbeam_images,
+                                make_qa_report,
+                                organise_qa_output)
 
 log = logging.getLogger('katacomb')
 # Tag to append to the output directory while the pipeline runs


### PR DESCRIPTION
This fixes an issue where the scripts cannot be run from outside the katsdpcontim docker container due to them requiring the Meerkat-continuum-validation library to be placed in `/home/kat/valid` on the local filesystem (a location that isn't generally writeable by any given user on any given machine).
The fix is simply to move the import of the continuum validation machinery out of the module and into the online (`continuum_pipeluine.py`) script. This allows the offline scripts to be run without trying to import the QA code, which they don't actually use anyway. Now the offline scripts can be run from outside or inside the docker container, but the online script can only be run from inside the docker container (unless the appropriate software is copied to `/home/kat/valid` on the host machine). This is likely the desired behaviour in any case.