### PR TITLE
Updates to ensure compatibility with Python 3.10

### DIFF
--- a/katacomb/katacomb/aips_export.py
+++ b/katacomb/katacomb/aips_export.py
@@ -210,8 +210,8 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
                                         kat_adapter.katdal, out_filebase)
 
         except Exception as e:
-            log.warn("Export of FITS and PNG images from %s failed.\n%s",
-                     clean_file, str(e))
+            log.warning("Export of FITS and PNG images from %s failed.\n%s",
+                        clean_file, str(e))
 
     # Export metadata json
     try:
@@ -221,7 +221,7 @@ def export_images(clean_files, target_indices, disk, kat_adapter):
         with open(metadata_file, 'w') as meta:
             json.dump(metadata, meta)
     except Exception as e:
-        log.warn("Creation of %s failed.\n%s", METADATA_JSON, str(e))
+        log.warning("Creation of %s failed.\n%s", METADATA_JSON, str(e))
 
     return metadata
 
@@ -250,7 +250,7 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
     pSN = mfimage_params.get('maxPSCLoop', mfimage_defaults['maxPSCLoop'])
     # If maxPSCLoop is 0 or less then there was no self-calibration
     if pSN < 1:
-        log.warn('No self-calibration solutions available for export')
+        log.warning('No self-calibration solutions available for export')
         return
     # Amp+phase gains are in SN version maxPSCLoop + maxASCLoop (if maxASCLoop > 0)
     apSN = mfimage_params.get('maxASCLoop', mfimage_defaults['maxASCLoop'])
@@ -318,8 +318,8 @@ def export_calibration_solutions(uv_files, kat_adapter, mfimage_params, telstate
                     ts.add('product_GAMP_PHASE', gain,
                            ts=katdal_timestamps(timestamp, kat_adapter.midnight))
         except Exception as e:
-            log.warn("Export of calibration solutions from '%s' failed.\n%s",
-                     uv_file, str(e))
+            log.warning("Export of calibration solutions from '%s' failed.\n%s",
+                        uv_file, str(e))
 
 
 AIPS_NAN = np.float32(np.array(b'INDE').view(np.float32))
@@ -402,7 +402,7 @@ def export_clean_components(clean_files, target_indices, kat_adapter, telstate):
         try:
             with img_factory(aips_path=clean_file, mode='r') as cf:
                 if "AIPS CC" not in cf.tables:
-                    log.warn("No clean components in '%s'", clean_file)
+                    log.warning("No clean components in '%s'", clean_file)
                 else:
                     target = "target%d" % si
 
@@ -420,8 +420,8 @@ def export_clean_components(clean_files, target_indices, kat_adapter, telstate):
                     telstate[key] = data
 
         except Exception as e:
-            log.warn("Export of clean components from '%s' failed.\n%s",
-                     clean_file, str(e))
+            log.warning("Export of clean components from '%s' failed.\n%s",
+                        clean_file, str(e))
 
 
 def cc_to_katpoint(img, order=2):
@@ -542,8 +542,8 @@ def fit_flux_model(nu, s, nu0, sigma, sref, stokes=1, order=2):
         try:
             popt, _ = curve_fit(obit_flux_model, lnunu0, s, p0=init[:fitorder + 1], sigma=sigma)
         except RuntimeError:
-            log.warn("Fitting flux model of order %d to CC failed. Trying lower order fit." %
-                     (fitorder,))
+            log.warning("Fitting flux model of order %d to CC failed. Trying lower order fit." %
+                        (fitorder,))
         else:
             coeffs = np.pad(popt, ((0, order - fitorder),), "constant")
             return obit_flux_model_to_katpoint(nu0, stokes, *coeffs)

--- a/katacomb/katacomb/aips_path.py
+++ b/katacomb/katacomb/aips_path.py
@@ -236,7 +236,7 @@ class AIPSPath(object):
             _check_disk_type(dtype, False)
 
 
-_AIPS_PATH_TUPLE_ARGS = [a for a in inspect.getargspec(AIPSPath.__init__).args
+_AIPS_PATH_TUPLE_ARGS = [a for a in inspect.getfullargspec(AIPSPath.__init__).args
                          if not a == "self"]
 _AIPS_PATH_TUPLE_FORMAT = "(%s)" % ",".join(_AIPS_PATH_TUPLE_ARGS)
 _AIPS_PATH_HELP = ("AIPS path should be a tuple of "

--- a/katacomb/katacomb/aips_table.py
+++ b/katacomb/katacomb/aips_table.py
@@ -141,7 +141,7 @@ class AIPSTableKeywords(object):
             key values to set.
         """
         if other is not None:
-            is_map = isinstance(other, collections.Mapping)
+            is_map = isinstance(other, collections.abc.Mapping)
             for k, v in other.items() if is_map else other:
                 self.__setitem__(k, v)
 

--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -659,7 +659,7 @@ class KatdalPipelineImplementation(PipelineImplementation):
                                                           merge_uvf, blavg_uvf,
                                                           nx_row)
             else:
-                log.warn("No visibilities to merge for scan %d", si)
+                log.warning("No visibilities to merge for scan %d", si)
 
             # Remove scan once merged
             if 'scans' in self.clobber:

--- a/katacomb/katacomb/img_facade.py
+++ b/katacomb/katacomb/img_facade.py
@@ -345,7 +345,7 @@ class ImageFacade(object):
         try:
             self._requireObitImageMF()
         except ValueError:
-            log.warn("%s is not an ImageMF.", self.name)
+            log.warning("%s is not an ImageMF.", self.name)
             imgMF = None
         else:
             imgMF = open_img(self._aips_path, mode=self.mode, MF=True)

--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -1174,9 +1174,9 @@ def time_chunked_scans(kat_adapter, time_step=4):
     EIGHT_GB = 8*1024**3
 
     if vis_size_estimate > EIGHT_GB:
-        log.warn("Visibility chunk '%s' is greater than '%s'. "
-                 "Check that sufficient memory is available",
-                 fmt_bytes(vis_size_estimate), fmt_bytes(EIGHT_GB))
+        log.warning("Visibility chunk '%s' is greater than '%s'. "
+                    "Check that sufficient memory is available",
+                    fmt_bytes(vis_size_estimate), fmt_bytes(EIGHT_GB))
 
     # Get some memory to hold reorganised visibilities
     out_vis = np.empty(out_vis_shape, dtype=kat_adapter.uv_vis.dtype)

--- a/katacomb/katacomb/katdal_adapter.py
+++ b/katacomb/katacomb/katdal_adapter.py
@@ -335,7 +335,7 @@ def aips_catalogue(katdata, nif):
             # (say for a mosaic).# "SOURCE" plus "QUAL" uniquely define
             # an entry in the table. The MeerKAT field of view is SO HUGE
             # I can't see this being needed.
-            'QUAL': [0.0],      # Source Qualifier Number
+            'QUAL': [0],      # Source Qualifier Number
         }
 
         used.append(source_name)

--- a/katacomb/katacomb/mock_dataset.py
+++ b/katacomb/katacomb/mock_dataset.py
@@ -104,7 +104,7 @@ def DEFAULT_WEIGHTS(dataset):
 
 
 def DEFAULT_FLAGS(dataset):
-    flags = np.zeros(dataset.shape, dtype=np.bool)
+    flags = np.zeros(dataset.shape, dtype=bool)
     # Flag 10% of visibilities
     nflagged = int(0.1*flags.size)
     flags.ravel()[-nflagged:] = True
@@ -246,9 +246,9 @@ class MockDataSet(DataSet):
         nchan = self.channels.shape[0]
 
         # Select everything upfront (weights + flags already set to all in superclass)
-        self._time_keep = np.ones(self._ndumps, dtype=np.bool)
-        self._corrprod_keep = np.ones(ncorrproducts, dtype=np.bool)
-        self._freq_keep = np.ones(nchan, dtype=np.bool)
+        self._time_keep = np.ones(self._ndumps, dtype=bool)
+        self._corrprod_keep = np.ones(ncorrproducts, dtype=bool)
+        self._freq_keep = np.ones(nchan, dtype=bool)
         self._create_azel_sensors()
         ants = [ant.name for ant in self.ants]
         self.select(ants=ants, spw=0, subarray=0)
@@ -426,8 +426,8 @@ class MockDataSet(DataSet):
 
     def _create_azel_sensors(self):
         """Generate azimuth and elevation sensors."""
-        az = np.recarray((self._ndumps), dtype=[('timestamp', np.float), ('value', np.float)])
-        el = np.recarray((self._ndumps), dtype=[('timestamp', np.float), ('value', np.float)])
+        az = np.recarray((self._ndumps), dtype=[('timestamp', float), ('value', float)])
+        el = np.recarray((self._ndumps), dtype=[('timestamp', float), ('value', float)])
         az['timestamp'] = self._timestamps
         el['timestamp'] = self._timestamps
         for ant in self.ants:

--- a/katacomb/katacomb/mock_dataset.py
+++ b/katacomb/katacomb/mock_dataset.py
@@ -65,7 +65,7 @@ DEFAULT_SPWS = [{
 # Pick 10 random ephem stars as katpoint targets
 _NR_OF_DEFAULT_TARGETS = 10
 DEFAULT_TARGETS = [katpoint.Target("%s, star" % t) for t in
-                   random.sample(stars.keys(), _NR_OF_DEFAULT_TARGETS)]
+                   random.sample(list(stars.keys()), _NR_OF_DEFAULT_TARGETS)]
 
 # Slew for 1 dumps then track for 4 on random targets
 _SLEW_TRACK_DUMPS = (('slew', 1), ('track', 4))

--- a/katacomb/katacomb/qa_report.py
+++ b/katacomb/katacomb/qa_report.py
@@ -55,7 +55,7 @@ def write_metadata(metadata, out_dir):
         with open(metadata_file, 'w') as meta:
             json.dump(metadata, meta)
     except Exception as e:
-        log.warn("Creation of %s failed.\n%s", metadata_file, str(e))
+        log.warning("Creation of %s failed.\n%s", metadata_file, str(e))
 
 
 def make_image_metadata(metadata, suffix, outdir, i, rname, desc, rmsnoise):

--- a/katacomb/katacomb/tests/test_aips_facades.py
+++ b/katacomb/katacomb/tests/test_aips_facades.py
@@ -46,7 +46,7 @@ class TestAipsFacades(unittest.TestCase):
 
         # Pick 5 random stars as targets
         targets = [katpoint.Target("%s, star" % t) for t in
-                   random.sample(stars.keys(), 5)]
+                   random.sample(list(stars.keys()), 5)]
 
         # track for 5 on each target
         slew_track_dumps = (('track', 5),)

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -64,9 +64,9 @@ def weights(dataset):
 
 def flags(dataset, flagged=False):
     if not flagged:
-        return np.zeros(dataset.shape, dtype=np.bool)
+        return np.zeros(dataset.shape, dtype=bool)
     else:
-        return np.ones(dataset.shape, dtype=np.bool)
+        return np.ones(dataset.shape, dtype=bool)
 
 
 def _check_fits_headers(filepath):
@@ -484,12 +484,12 @@ class TestOnlinePipeline(unittest.TestCase):
         """
         input_freqs = np.linspace(100.e6, 500.e6, 10)
         lnunu0 = np.log(input_freqs / input_freqs[5])
-        input_cc_tab = np.ones((4, 10), dtype=np.float)
+        input_cc_tab = np.ones((4, 10), dtype=float)
         input_cc_tab[0] = obit_flux_model(lnunu0, 10.)
         input_cc_tab[1] = obit_flux_model(lnunu0, -10., -0.7)
         input_cc_tab[2] = obit_flux_model(lnunu0, 2., 0.1, 0.01)
         input_cc_tab[3] = obit_flux_model(lnunu0, -0.5, -0.5, 0.01, 0.05)
-        input_sigma = np.ones(10, dtype=np.float) * 0.1
+        input_sigma = np.ones(10, dtype=float) * 0.1
         for order in range(4):
             cc_tab = input_cc_tab[order]
             kp_model = fit_flux_model(input_freqs, cc_tab, input_freqs[0],

--- a/katacomb/katacomb/tests/test_qa.py
+++ b/katacomb/katacomb/tests/test_qa.py
@@ -100,7 +100,7 @@ def _check_keys(meta_file, meta_in, suffix, i, name):
 
 
 class TestMakePBImages:
-    def setup(self):
+    def setup_method(self):
         # Create temporary directory
         self.tmpdir_in = tempfile.TemporaryDirectory()
         in_array = np.ones([1, 3, 100, 100])
@@ -117,7 +117,7 @@ class TestMakePBImages:
             inFileName = os.path.join(self.tmpdir_in.name, '1234.writing', f)
             hdu.writeto(inFileName)
 
-    def teardown(self):
+    def teardown_method(self):
         self.tmpdir_in.cleanup()
 
     def test_make_pb_images(self):
@@ -135,7 +135,7 @@ class TestMakePBImages:
 
 
 class TestMakeQAReport:
-    def setup(self):
+    def setup_method(self):
         # create temporary directory
         self.tmpdir_in = tempfile.TemporaryDirectory()
 
@@ -175,7 +175,7 @@ class TestMakeQAReport:
             inFileName = os.path.join(outDirName + '_PB.writing', file_base + '_PB' + FITS_EXT)
             hdu.writeto(inFileName)
 
-    def teardown(self):
+    def teardown_method(self):
         self.tmpdir_in.cleanup()
 
     def test_organise_qa_output(self):

--- a/katacomb/katacomb/tests/test_uv_export.py
+++ b/katacomb/katacomb/tests/test_uv_export.py
@@ -139,7 +139,7 @@ class TestUVExport(unittest.TestCase):
             'band': 'L',
         }]
 
-        target_names = random.sample(stars.keys(), 5)
+        target_names = random.sample(list(stars.keys()), 5)
 
         # Pick 5 random stars as targets
         targets = [katpoint.Target("%s, star" % t) for t in target_names]

--- a/katacomb/katacomb/tests/test_uv_export.py
+++ b/katacomb/katacomb/tests/test_uv_export.py
@@ -95,7 +95,7 @@ class TestUVExport(unittest.TestCase):
 
         # Flag the data
         def mock_flags(dataset):
-            return np.ones(dataset.shape, dtype=np.bool)
+            return np.ones(dataset.shape, dtype=bool)
 
         # Create Mock dataset and wrap it in a KatdalAdapter
         ds = MockDataSet(timestamps=DEFAULT_TIMESTAMPS,

--- a/katacomb/katacomb/tests/test_uv_export.py
+++ b/katacomb/katacomb/tests/test_uv_export.py
@@ -245,9 +245,9 @@ class TestUVExport(unittest.TestCase):
 
                 # Check that the subset of keywords generated
                 # by the katdal adapter match those read from the AIPS table
-                self.assertDictContainsSubset(KA.uv_spw_keywords, fq_kw)
-                self.assertDictContainsSubset(KA.uv_source_keywords, src_kw)
-                self.assertDictContainsSubset(KA.uv_antenna_keywords, ant_kw)
+                self.assertEqual(fq_kw, {**fq_kw, **KA.uv_spw_keywords})
+                self.assertEqual(src_kw, {**src_kw, **KA.uv_source_keywords})
+                self.assertEqual(ant_kw, {**ant_kw, **KA.uv_antenna_keywords})
 
                 def _strip_metadata(aips_table_rows):
                     """

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -130,10 +130,10 @@ def post_process_args(args, kat_ds):
             args.capture_block_id = kat_ds.name[0:10]
         except AttributeError:
             args.capture_block_id = kat_ds.experiment_id
-            log.warn("No capture block ID was specified or "
-                     "found in katdal. "
-                     "Using experiment_id '%s' instead.",
-                     kat_ds.experiment_id)
+            log.warning("No capture block ID was specified or "
+                        "found in katdal. "
+                        "Using experiment_id '%s' instead.",
+                        kat_ds.experiment_id)
     telstate_id = getattr(args, 'telstate_id', None)
     args.output_id = getattr(args, 'output_id', '')
     if telstate_id is None:
@@ -181,8 +181,8 @@ def get_and_merge_args(collection, config_file, args):
     """
 
     if not os.path.exists(config_file):
-        log.warn("Specified configuration file %s not found. "
-                 "Using Obit default parameters.", config_file)
+        log.warning("Specified configuration file %s not found. "
+                    "Using Obit default parameters.", config_file)
         out_args = {}
     else:
         out_args = yaml.safe_load(open(config_file))[collection]
@@ -484,7 +484,7 @@ def normalise_target_name(name, used=[], max_length=None):
         # If the length of i_name is greater than ml
         # just warn and revert to straight append
         if len(i_name) >= ml:
-            log.warn('Too many repetitions of name %s.', name)
+            log.warning('Too many repetitions of name %s.', name)
             t_name = name
         o_name = ''.join(filter(None, [t_name, i_name]))
         return '{:{ml}.{ml}}'.format(o_name, ml=ml)

--- a/katacomb/requirements.txt
+++ b/katacomb/requirements.txt
@@ -1,16 +1,16 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 AegeanTools == 2.2.0   # for MeerKAT-continuum-validation
-asteval == 0.9.21      # for MeerKAT-continuum-validation
+asteval == 0.9.29      # for MeerKAT-continuum-validation
 astropy
 attrs
-cerberus == 1.1
+cerberus == 1.3.4
 dask
 docopt == 0.6.2        # for MeerKAT-continuum-validation
-healpy == 1.14.0       # for MeerKAT-continuum-validation
+healpy == 1.16.2       # for MeerKAT-continuum-validation
 Jinja2                 # for MeerKAT-continuum-validation
-lmfit == 1.0.1         # for MeerKAT-continuum-validation
+lmfit == 1.2.1         # for MeerKAT-continuum-validation
 matplotlib             # for MeerKAT-continuum-validation
-mpld3 == 0.5.2         # for MeerKAT-continuum-validation
+mpld3 == 0.5.9         # for MeerKAT-continuum-validation
 numba
 numpy
 pandas                 # for MeerKAT-continuum-validation
@@ -19,8 +19,8 @@ pytest
 pytz                   # for MeerKAT-continuum-validation
 pyyaml
 scipy
-seaborn == 0.10.1      # for MeerKAT-continuum-validation
-uncertainties == 3.1.4 # for MeerKAT-continuum-validation
+seaborn == 0.12.2      # for MeerKAT-continuum-validation
+uncertainties == 3.1.7 # for MeerKAT-continuum-validation
 
 katbeam @ git+https://github.com/ska-sa/katbeam  # for katsdpimageutils
 katdal[s3credentials] @ git+https://github.com/ska-sa/katdal

--- a/katacomb/scripts/cfg_aips_disks.py
+++ b/katacomb/scripts/cfg_aips_disks.py
@@ -110,8 +110,8 @@ def link_obit_data():
             try:
                 os.symlink(data_file, link_name)
             except OSError as e:
-                log.warn("Unable to link '{}' to '{}'\n"
-                         "{}".format(link_name, data_file, e))
+                log.warning("Unable to link '{}' to '{}'\n"
+                            "{}".format(link_name, data_file, e))
 
 
 def create_parser():


### PR DESCRIPTION
Fix some warnings in Python 3.8 and dependencies that are broken in Python 3.10.
The first commit bumps some local dependent packages in `requirements.txt` - Other unpinned packages (like `numba`, `numpy` & `dask`) are pinned in dockerbase and someone will have to work out suitable versions of these separately.
The remaining commits can be followed one at a time, and fix things that are spitting warnings about being deprecated or are broken in Python>=3.8.