### PR TITLE
SPR1-3213 make UVFacade sequential write work again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
+ARG KATSDPDOCKERBASE_REGISTRY=harbor.sdp.kat.ac.za/dpp
 
 FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-gpu-build as build
 
@@ -62,13 +62,15 @@ ENV KATHOME=/home/kat
 # Now downgrade to kat
 USER kat
 
-ENV OBIT_REPO https://github.com/bill-cotton/Obit/trunk/ObitSystem
+ENV OBIT_REPO https://github.com/bill-cotton/Obit
 ENV OBIT_BASE_PATH=/home/kat/Obit
 ENV OBIT=/home/kat/Obit/ObitSystem/Obit
 
-# Retrieve Obit r651
-RUN mkdir -p $OBIT_BASE_PATH && \
-    svn co -q -r 651 $OBIT_REPO ${OBIT_BASE_PATH}/ObitSystem
+WORKDIR $KATHOME
+RUN git clone -n --depth=1 --filter=tree:0 $OBIT_REPO && \
+    cd $OBIT_BASE_PATH && \
+    git sparse-checkout set --no-cone ObitSystem && \
+    git checkout
 
 WORKDIR $OBIT_BASE_PATH
 

--- a/katacomb/katacomb/tests/test_aips_facades.py
+++ b/katacomb/katacomb/tests/test_aips_facades.py
@@ -84,8 +84,8 @@ class TestAipsFacades(unittest.TestCase):
                     times = np.arange(firstVis, firstVis+numVisBuff, dtype=np.float32)
 
                     buf = uvf.np_visbuf
-                    buf[iloct:lrec*numVisBuff:lrec] = times
-                    uvf.Write(firstVis=firstVis)
+                    buf[iloct:iloct + lrec*numVisBuff:lrec] = times
+                    uvf.Write()
 
             # Now re-open in readonly mode and test
             # that we get the same sequential values out
@@ -112,7 +112,7 @@ class TestAipsFacades(unittest.TestCase):
                     buf = uvf.np_visbuf
 
                     times = np.arange(firstVis, firstVis+numVisBuff, dtype=np.float32)
-                    buf_times = buf[iloct:lrec*numVisBuff:lrec]
+                    buf_times = buf[iloct:iloct + lrec*numVisBuff:lrec]
                     self.assertTrue(np.all(times == buf_times))
 
 

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -572,7 +572,7 @@ class TestOnlinePipeline(unittest.TestCase):
             test_freqs = np.linspace(out_fluxmodel.min_freq_MHz, out_fluxmodel.max_freq_MHz, 5)
             in_flux = in_fluxmodel.flux_density(test_freqs)
             out_flux = out_fluxmodel.flux_density(test_freqs)
-            np.testing.assert_allclose(out_flux, in_flux, rtol=1.e-3)
+            np.testing.assert_allclose(out_flux, in_flux, rtol=2.e-3)
 
         # A field with some off axis sources to check positions
         offax_cat = katpoint.Catalogue()

--- a/katacomb/katacomb/tests/test_continuum_pipeline.py
+++ b/katacomb/katacomb/tests/test_continuum_pipeline.py
@@ -523,7 +523,8 @@ class TestOnlinePipeline(unittest.TestCase):
         cat = katpoint.Catalogue()
         cat.add(katpoint.Target("Amfortas, radec, 0.0, -90.0, (856. 1712. 1. 0. 0.)"))
         cat.add(katpoint.Target("Klingsor, radec, 0.0, 0.0, (856. 1712. 2. -0.7 0.1)"))
-        cat.add(katpoint.Target("Kundry, radec, 100.0, -35.0, (856. 1712. -1.0 1. -0.1)"))
+        cat.add(katpoint.Target("Kundry, radec, 100.0, -35.0, (856. 1712. -1.0 0. 0.)"))
+        cat.add(katpoint.Target("Gurnemanz, radec, 10.0, 10.0, (856. 1712. 0.34 -0.15 0.0 0.0 2.3 -1.0 1.0 0.2 -0.1 0.0)"))
 
         ts = TelescopeState()
 

--- a/katacomb/katacomb/uv_facade.py
+++ b/katacomb/katacomb/uv_facade.py
@@ -476,7 +476,7 @@ class UVFacade(object):
         err_msg = "Error writing UV file '%s'" % self.name
 
         try:
-            self.uv.Write(self._err, firstVis=firstVis)
+            self.uv.Write(self._err)
         except Exception:
             raise Exception(err_msg)
 


### PR DESCRIPTION
The background to this PR is that katsdpcontim hasn't built on CI/Jenkins for some time. This is due to Github sunsetting svn support https://github.blog/news-insights/product-news/sunsetting-subversion-support/. I've changed the dockerfile so that Obit is built from source at its github URL, rather than a pinned svn-over-git version. This has had several side-effects, the first being that Obit version has been updated to 668.

As a consequence of this, katsdpcontim no longer behaves as it did previously. I narrowed it down to the way sequential writes are handled in UVFacade. There was an interesting-in-its-logic switch on a parameter passed to the ::Write method, that would affect the previous buffer pointer in Obit. I assume this had been done to work around behaviour of Obit at that time. However, Obit no longer seems to require this work-around, so I removed it. This is a potentially major change.

Minor changes are to use harbor as the base registry rather than sdp-docker-registry to bring katsdpcontim into alignment with other SDP components, modify upward the tolerance on flux fidelity tests, and change what I believe was an error with slices on uv_facade read/write tests.