### PR TITLE
changed maxFBW parameter from 0.038 to 0.039 for MKAT_wide_S.yaml

### DIFF
--- a/katacomb/katacomb/conf/parameters/MKAT_wide_S.yaml
+++ b/katacomb/katacomb/conf/parameters/MKAT_wide_S.yaml
@@ -15,7 +15,7 @@ mfimage:
   Stokes: 'I'                 # Stokes to process
   norder: 1                   # Maximum order of spectral terms
   Alpha: 0.0                  # Spectral Index to correct
-  maxFBW: 0.038               # Max. fractional sub-band center bandwidth
+  maxFBW: 0.039               # Max. fractional sub-band center bandwidth
   FOV: 0.65                   # Radius of field to image (deg)
   xCells: 0.0                 # Image cell spacing in X in asec.
   yCells: 0.0                 # Image cell spacing in Y in asec.


### PR DESCRIPTION
SPR1-196, On certain S-band observations the Imaging pipeline is producing images with no input in the First Plane of the image. This seems to be because of a poorly chosen maxFBW parameter which for the higher frequency S-band observations splits the band into planes where the final plan is so small it fits into the static masked region. This static masked region is completely flagged and combining this now empty image in the plane with other planes results in the undesirable problem of the first plane becoming a NaN . This results in no continuum image being produced for the observation. Better results at these higher frequencies are achieved by setting maxFBW=0.039.