### PR TITLE
Fix selection of multiple targets

### DIFF
--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -677,7 +677,7 @@ def setup_selection_and_parameters(katdata, args):
     if getattr(args, 'pol', None):
         kat_select['pol'] = args.pols
     if getattr(args, 'targets', None):
-        kat_select['targets'] = args.targets
+        kat_select['targets'] = args.targets.split(',')
     if getattr(args, 'channels', None):
         start_chan, end_chan = args.channels
         kat_select['channels'] = slice(start_chan, end_chan)

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -677,7 +677,7 @@ def setup_selection_and_parameters(katdata, args):
     if getattr(args, 'pol', None):
         kat_select['pol'] = args.pols
     if getattr(args, 'targets', None):
-        kat_select['targets'] = args.targets.split(',')
+        kat_select['targets'] = [t.strip() for t in args.targets.split(',')]
     if getattr(args, 'channels', None):
         start_chan, end_chan = args.channels
         kat_select['channels'] = slice(start_chan, end_chan)


### PR DESCRIPTION
Currently the script is supplying multiple targets as a string of comma separated target names to a katdal select statement, but it should be a comma separated list.