### PR TITLE
Improve default time_step selection

### DIFF
--- a/katacomb/katacomb/continuum_pipeline.py
+++ b/katacomb/katacomb/continuum_pipeline.py
@@ -699,7 +699,7 @@ class KatdalPipelineImplementation(PipelineImplementation):
 class KatdalExportPipeline(KatdalPipelineImplementation):
 
     def __init__(self, katdata, uvblavg_params={}, katdal_select={},
-                 nvispio=1024, merge_scans=False, out_path=None):
+                 nvispio=1024, merge_scans=False, out_path=None, time_step=20):
         """Initialise a pipeline for UV export from katdal to AIPS UV.
 
         Parameters
@@ -716,6 +716,8 @@ class KatdalExportPipeline(KatdalPipelineImplementation):
             Don't do BL dependant averaging if True.
         out_path : :class:AIPSPath
             Output file path on AIPS disk.
+        time_step : int
+            Size of time chunks to read vis, weights & flags from katdata
         """
 
         super(KatdalExportPipeline, self).__init__(katdata)
@@ -726,6 +728,7 @@ class KatdalExportPipeline(KatdalPipelineImplementation):
         self.out_path = out_path
         # Always get rid of scan and avgscan files
         self.clobber = ['scans', 'avgscans']
+        self.time_step = time_step
 
     def __enter__(self):
         return self
@@ -758,7 +761,7 @@ class KatdalExportPipeline(KatdalPipelineImplementation):
 class OnlinePipeline(KatdalPipelineImplementation):
 
     def __init__(self, katdata, telstate, uvblavg_params={}, mfimage_params={},
-                 katdal_select={}, nvispio=1024):
+                 katdal_select={}, nvispio=1024, time_step=20):
         """
         Initialise the Continuum Pipeline for MeerKAT system processing.
 
@@ -776,6 +779,8 @@ class OnlinePipeline(KatdalPipelineImplementation):
             Dictionary of katdal selection statements.
         nvispio : integer
             Number of AIPS visibilities per IO operation.
+        time_step : int
+            Size of time chunks to read vis, weights & flags from katdata
         """
 
         super(OnlinePipeline, self).__init__(katdata)
@@ -784,6 +789,7 @@ class OnlinePipeline(KatdalPipelineImplementation):
         self.mfimage_params.update(mfimage_params)
         self.katdal_select = katdal_select
         self.nvispio = nvispio
+        self.time_step = time_step
 
         # Use highest numbered FITS disk for FITS output.
         self.odisk = len(kc.get_config()['fitsdirs'])

--- a/katacomb/katacomb/util/__init__.py
+++ b/katacomb/katacomb/util/__init__.py
@@ -683,6 +683,8 @@ def setup_selection_and_parameters(katdata, args):
         kat_select['channels'] = slice(start_chan, end_chan)
     if getattr(args, 'nif', None):
         kat_select['nif'] = args.nif
+    if getattr(args, 'time_step', None):
+        kat_select['time_step'] = args.time_step
     # Get defaults from katdal object
     uvblavg_defaults, mfimage_defaults, select_defaults = infer_defaults_from_katdal(katdata)
     # Command line katdal selection overrides command line options
@@ -757,6 +759,9 @@ def infer_defaults_from_katdal(katds):
     if katds.spectral_windows[katds.spw].bandwidth < 200.e6:
         # Narrow
         katdal_select['nif'] = 2
+    katdal_select['time_step'] = 20
+    if len(katds.freqs) > 4096:
+        katdal_select['time_step'] = 4
     return uvblavg_params, mfimage_params, katdal_select
 
 

--- a/katacomb/scripts/continuum_image.py
+++ b/katacomb/scripts/continuum_image.py
@@ -59,6 +59,12 @@ def create_parser():
                              "'clean' => Output CLEAN files. "
                              "'mfimage' => Output MFImage files. "
                              "Default: %(default)s")
+    parser.add_argument("--time_step",
+                        default=None,
+                        type=int,
+                        help="Size of time chunks to read vis,"
+                             "weights & flags from katdata"
+                             "Default: 20 for <=4k and 4 for >4k chans")
     parser.add_argument("--log-level",
                         type=str,
                         default="INFO",
@@ -82,6 +88,7 @@ def main():
     (uvblavg_defaults,
      mfimage_defaults,
      kat_select) = setup_selection_and_parameters(katdata, args)
+    time_step = kat_select.pop('time_step')
 
     # Merge parameters for Obit from parameter files with command line parameters
     uvblavg_parm_file = get_parameter_file(katdata, args.uvblavg_config)
@@ -111,6 +118,7 @@ def main():
                                 mfimage_params=mfimage_args,
                                 nvispio=args.nvispio,
                                 clobber=args.clobber,
+                                time_step=time_step,
                                 prtlv=args.prtlv,
                                 reuse=bool(args.reuse))
 

--- a/katacomb/scripts/continuum_pipeline.py
+++ b/katacomb/scripts/continuum_pipeline.py
@@ -93,6 +93,13 @@ def create_parser():
                         help="Label the product of the continuum pipeline. "
                              "Used to generate FITS and PNG filenames. "
                              "Default: %(default)s")
+    parser.add_argument("--time_step",
+                        default=None,
+                        type=int,
+                        help="Size of time chunks to read vis,"
+                             "weights & flags from katdata"
+                             "Default: 20 for <=4k and 4 for >4k chans")
+
     katdal_options(parser)
     export_options(parser)
     imaging_options(parser)
@@ -124,6 +131,7 @@ def main():
     (uvblavg_defaults,
      mfimage_defaults,
      katdal_select) = setup_selection_and_parameters(katdata, args)
+    time_step = katdal_select.pop('time_step')
 
     # Merge Obit parameters Obit from parameter files with command line parameters
     uvblavg_parm_file = get_parameter_file(katdata, args.uvblavg_config, online=True)
@@ -162,7 +170,8 @@ def main():
                                 katdal_select=katdal_select,
                                 uvblavg_params=uvblavg_args,
                                 mfimage_params=mfimage_args,
-                                nvispio=args.nvispio)
+                                nvispio=args.nvispio,
+                                time_step=time_step)
 
     # Execute it
     metadata = pipeline.execute()

--- a/katacomb/scripts/uv_export.py
+++ b/katacomb/scripts/uv_export.py
@@ -51,6 +51,12 @@ def create_parser():
     parser.add_argument("--average",
                         action='store_true',
                         help="Switch on BL dependent averaging and channel averaging")
+    parser.add_argument("--time_step",
+                        default=None,
+                        type=int,
+                        help="Size of time chunks to read vis,"
+                             "weights & flags from katdata"
+                             "Default: 20 for <=4k and 4 for >4k chans")
     parser.add_argument("--log-level",
                         type=str,
                         default="INFO",
@@ -70,6 +76,7 @@ def main():
     post_process_args(args, katdata)
 
     uvblavg_defaults, _, kat_select = setup_selection_and_parameters(katdata, args)
+    time_step = kat_select.pop('time_step')
 
     # Merge parameters for Obit from parameter files with command line parameters
     uvblavg_parm_file = get_parameter_file(katdata, args.uvblavg_config)
@@ -92,7 +99,8 @@ def main():
                                 uvblavg_params=uvblavg_args,
                                 merge_scans=not args.average,
                                 nvispio=args.nvispio,
-                                out_path=out_file)
+                                out_path=out_file,
+                                time_step=time_step)
     pipeline.execute()
 
 


### PR DESCRIPTION
The current default time_step of 20 for all datasets results in very large chunks of katdal data being loaded for 32k datasets. Use an improved default of 4 time_steps for large (>4k) datasets and allow this to be a selectable parameter in the scripts going forward.